### PR TITLE
fix: resolve git clone URL at runtime — SSH > gh CLI > error

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -623,7 +623,6 @@ INSTALL_OBSIDIAN=${shq(bool(d.installObsidian))}
 INSTALL_FIRECRAWL=${shq(bool(d.installFirecrawl))}
 
 # ───── Constants ─────
-MYCROFT_REPO='https://github.com/buriedsignals/mycroft.git'
 MYCROFT_DIR="$HOME/.mycroft"
 GOOSE_CONFIG="$HOME/.config/goose"
 PROVIDERS_DST="$GOOSE_CONFIG/custom_providers"
@@ -640,6 +639,18 @@ say()  { printf "\\n\\033[1;34m>\\033[0m %s\\n" "$*"; }
 ok()   { printf "  \\033[1;32m+\\033[0m %s\\n" "$*"; }
 warn() { printf "  \\033[1;33m!\\033[0m %s\\n" "$*"; }
 err()  { printf "  \\033[1;31mX\\033[0m %s\\n" "$*" >&2; }
+
+# Resolve clone URL: SSH > gh CLI (HTTPS with token) > fail with actionable message
+if ssh -o BatchMode=yes -o ConnectTimeout=5 -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+  MYCROFT_REPO='git@github.com:buriedsignals/mycroft.git'
+elif have gh && gh auth status >/dev/null 2>&1; then
+  MYCROFT_REPO=$(gh repo view buriedsignals/mycroft --json sshUrl -q .sshUrl 2>/dev/null || echo 'git@github.com:buriedsignals/mycroft.git')
+else
+  err "Cannot authenticate with GitHub. Either:"
+  err "  - Add your SSH key: https://github.com/settings/keys"
+  err "  - Or install gh CLI and run: gh auth login"
+  exit 1
+fi
 
 say "Mycroft setup starting"
 echo "  sovereignty: $SOVEREIGNTY"


### PR DESCRIPTION
Closes #1

HTTPS auth is not supported by GitHub for private repos. Detects SSH availability at runtime (after helpers are defined), falls back to gh CLI token auth, or exits with an actionable message.

**Tested on:** macOS 25.3.0, SSH key registered on GitHub.