### PR TITLE
fix: add missing parameter defaults in vault-qa and fact-check recipes

### DIFF
--- a/recipes/fact-check.yaml
+++ b/recipes/fact-check.yaml
@@ -12,10 +12,12 @@ parameters:
     input_type: string
     requirement: optional
     description: "Path to the draft file (markdown, text, docx)"
+    default: ""
   - key: draft_text
     input_type: string
     requirement: optional
     description: "Draft text inline (use when draft is short and pastable)"
+    default: ""
 
 extensions:
   - type: builtin

--- a/recipes/vault-qa.yaml
+++ b/recipes/vault-qa.yaml
@@ -17,6 +17,11 @@ parameters:
     requirement: required
     description: "Absolute or ~-expanded path to the journalist's vault root"
     default: "~/Documents/Mycroft"
+  - key: entity
+    input_type: string
+    requirement: optional
+    description: "Entity name for activity suggestions (person, org, topic)"
+    default: "[entity]"
 
 extensions:
   - type: builtin


### PR DESCRIPTION
Closes #11
Closes #12

- `vault-qa`: `entity` used in `activities` but not declared as a parameter — Goose rejects the recipe on load
- `fact-check`: `draft_path` and `draft_text` are optional but missing `default` values — Goose requires defaults for optional params

**Tested on:** macOS 25.3.0, Goose CLI 1.31.0