### PR TITLE
fix: expand tilde in VAULT_PATH using JS replace (v2)

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -616,8 +616,7 @@ esac
 # ───── Your selections (from the setup form) ─────
 SOVEREIGNTY=${shq(d.sovereignty)}
 LOCAL_ONLY=${shq(bool(d.localOnly))}
-VAULT_PATH=${shq(d.vault)}
-VAULT_PATH="\${VAULT_PATH/#\\~/\$HOME}"
+VAULT_PATH="${d.vault.replace(/^~\//, '$HOME/')}"
 
 INSTALL_GOOSE=${shq(bool(d.installGoose))}
 INSTALL_OBSIDIAN=${shq(bool(d.installObsidian))}


### PR DESCRIPTION
Supersedes the bash-expansion approach in #14 which was broken by JS template literal escaping.

The `\${VAULT_PATH/#\\~/\$HOME}` line was silently dropped from the generated script because the nested escaping made the template literal output nothing.

Simpler fix: replace `~/` with `$HOME/` directly in JS before embedding in the script, using double quotes so bash expands `$HOME` at runtime.

Fixes #13