### PR TITLE
feat: landing page studio block — membership + consulting

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,43 @@
   .cta-footer h2 { margin-bottom: 1rem; }
   .cta-footer p { color: var(--muted); font-size: 1.05rem; margin: 0 auto 2rem; max-width: 32rem; }
 
+  /* Studio block — membership + consulting */
+  .studio-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; }
+  .studio-card { background: var(--bg-2); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 1.75rem; display: flex; flex-direction: column; }
+  .studio-card .eyebrow { color: var(--accent); font-weight: 700; font-size: .75rem; letter-spacing: .08em; text-transform: uppercase; margin-bottom: .5rem; }
+  .studio-card h3 { margin: 0 0 .35rem; font-size: 1.35rem; font-weight: 700; letter-spacing: -.01em; }
+  .studio-card .sub { margin: 0 0 1.25rem; color: var(--muted); font-size: .98rem; }
+  .studio-card ul.features { list-style: none; padding: 0; margin: 0 0 1.25rem; }
+  .studio-card ul.features li { padding: .7rem 0; border-bottom: 1px solid var(--border); font-size: .94rem; line-height: 1.5; }
+  .studio-card ul.features li:last-child { border-bottom: none; }
+  .studio-card .service { padding: .85rem 0; border-bottom: 1px solid var(--border); font-size: .94rem; line-height: 1.5; }
+  .studio-card .service:last-of-type { border-bottom: none; margin-bottom: .5rem; }
+  .studio-card .service strong { display: inline; color: var(--fg); font-weight: 600; }
+  .studio-card .service .clients { display: block; color: var(--muted); font-size: .85rem; margin-top: .3rem; }
+  .studio-card .price { color: var(--muted); font-size: .92rem; margin: 0 0 1rem; }
+  .studio-card .price strong { color: var(--fg); font-weight: 700; }
+  .studio-card .spacer { flex: 1; }
+  .signup-form .row { display: flex; gap: .5rem; flex-wrap: wrap; }
+  .signup-form input[type="email"] {
+    flex: 1; min-width: 0; padding: .75rem .9rem;
+    background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+    color: var(--fg); font-family: inherit; font-size: .95rem;
+  }
+  .signup-form input[type="email"]:focus { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
+  .signup-form button {
+    padding: .75rem 1.25rem; background: var(--fg); color: var(--bg);
+    border: none; border-radius: 6px; font-family: inherit;
+    font-size: .95rem; font-weight: 600; cursor: pointer;
+  }
+  .signup-form button:hover:not(:disabled) { background: var(--accent); }
+  .signup-form button:disabled { opacity: .6; cursor: default; }
+  .signup-error { color: #c94444; font-size: .86rem; margin-top: .5rem; }
+  @media (prefers-color-scheme: dark) { .signup-error { color: #e06a6a; } }
+  .signup-success { display: flex; align-items: center; gap: .5rem; color: var(--ok); font-size: .95rem; font-weight: 500; }
+  .consulting-cta { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .consulting-cta .link { color: var(--muted); font-size: .9rem; border-bottom: 1px solid var(--border); text-decoration: none; }
+  .consulting-cta .link:hover { color: var(--fg); border-bottom-color: var(--fg); text-decoration: none; }
+
   /* Footer */
   footer.site { border-top: 1px solid var(--border); padding: 2rem 0; color: var(--muted); font-size: .88rem; }
   footer.site .wrap { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 1rem; }
@@ -367,6 +404,65 @@
     </div>
   </section>
 
+  <section id="studio" aria-labelledby="studio-h">
+    <div class="wrap">
+      <h2 id="studio-h">From the team behind Mycroft</h2>
+
+      <div class="studio-grid">
+
+        <article class="studio-card">
+          <div class="eyebrow">Launching May 2026</div>
+          <h3>Pro Membership</h3>
+          <p class="sub">Investigations with AI. The tools to run your own.</p>
+          <ul class="features">
+            <li>Collaborative investigations — shared leads, data, and methodology</li>
+            <li>Live bootcamps, workshops, and events</li>
+            <li>Hosted Pro tier of the agent extensions — coJournalist, Navigator, Spotlight, DataHound</li>
+            <li>Investigation methodologies and AI techniques, in depth</li>
+          </ul>
+          <p class="price"><strong>From $25/mo</strong> · 400+ journalists already reading</p>
+          <div class="spacer"></div>
+          <form class="signup-form" id="signup-form">
+            <div class="row">
+              <input type="email" id="signup-email" placeholder="you@example.com" required autocomplete="email" aria-label="Email address">
+              <button type="submit" id="signup-submit">Subscribe</button>
+            </div>
+            <div class="signup-error" id="signup-error" hidden role="alert"></div>
+          </form>
+          <div class="signup-success" id="signup-success" hidden>
+            <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" fill="currentColor"/>
+            </svg>
+            <span>You're in. I'll ping you at launch.</span>
+          </div>
+        </article>
+
+        <article class="studio-card">
+          <h3>Consulting</h3>
+          <p class="sub">I train newsrooms to investigate with AI.</p>
+          <div class="service">
+            <strong>Workshops &amp; training</strong> — I run hands-on sessions where journalists investigate live stories with AI.
+            <span class="clients">Le Temps · MAZ Journalistenschule · Republik · 20 Minuten</span>
+          </div>
+          <div class="service">
+            <strong>Custom AI tooling</strong> — I build AI systems into your editorial workflow — archive search, source monitoring, research agents, whatever the newsroom needs.
+            <span class="clients">MediaStorm</span>
+          </div>
+          <div class="service">
+            <strong>Investigation collaborations</strong> — Visual production and AI pipelines paired with your field reporting.
+            <span class="clients">The New Humanitarian</span>
+          </div>
+          <div class="spacer"></div>
+          <div class="consulting-cta">
+            <a href="mailto:tom@buriedsignals.com?subject=Mycroft%20%E2%80%94%20Consulting" class="btn primary">Get in Touch →</a>
+            <a href="https://buriedsignals.com/consulting" target="_blank" rel="noreferrer" class="link">See case studies →</a>
+          </div>
+        </article>
+
+      </div>
+    </div>
+  </section>
+
   <section class="cta-footer" aria-labelledby="cta-h">
     <div class="wrap">
       <h2 id="cta-h">Built by journalists, for journalists.</h2>
@@ -390,6 +486,54 @@
     </nav>
   </div>
 </footer>
+
+<script>
+  const NEWSLETTER_ENDPOINT = '/api/newsletter/subscribe';
+
+  const form = document.getElementById('signup-form');
+  const emailInput = document.getElementById('signup-email');
+  const submitBtn = document.getElementById('signup-submit');
+  const errorEl = document.getElementById('signup-error');
+  const successEl = document.getElementById('signup-success');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = emailInput.value.trim();
+    if (!email) return;
+
+    submitBtn.disabled = true;
+    const originalText = submitBtn.textContent;
+    submitBtn.textContent = 'Subscribing…';
+    errorEl.hidden = true;
+
+    try {
+      const response = await fetch(NEWSLETTER_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, newsletters: ['buried_signals'] }),
+      });
+
+      if (response.ok) {
+        form.hidden = true;
+        successEl.hidden = false;
+      } else {
+        let message = 'Something went wrong. Please try again.';
+        try {
+          const data = await response.json();
+          if (data && data.detail) message = data.detail;
+        } catch (_) {}
+        errorEl.textContent = message;
+        errorEl.hidden = false;
+      }
+    } catch (err) {
+      errorEl.textContent = 'Something went wrong. Please try again.';
+      errorEl.hidden = false;
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = originalText;
+    }
+  });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a two-card "From the team behind Mycroft" section to `index.html`, inserted between `#plugins` and the closing `.cta-footer`.

- **Pro Membership card** — launching-May-2026 eyebrow, feature bullets (collaborative investigations, bootcamps/events, hosted Pro tier of the agent extensions, methodology in depth), price line, and a Resend newsletter signup form. Endpoint left as `const NEWSLETTER_ENDPOINT = '/api/newsletter/subscribe'` at the top of the inline script — swap to the real URL when backend is wired.
- **Consulting card** — three service lines (workshops & training, custom AI tooling, investigation collaborations) with case-study-backed clients (Le Temps, MAZ, Republik, 20 Minuten, MediaStorm, The New Humanitarian), `mailto:` CTA, and a plain-text link to `buriedsignals.com/consulting`.

Styling uses Mycroft's existing design tokens (`--bg-2`, `--border`, `--radius-lg`, `--accent`, `--ok`, `.btn.primary`). No new fonts, no external requests. CSP-compatible — the existing `'unsafe-inline'` script policy covers the submit handler.

Same block already shipped on `spotlight/landing.html` (`buriedsignals/spotlight@def431b`); copy is identical modulo the mailto subject (`Mycroft — Consulting` here).

## Test plan

- [ ] Open `index.html` locally, verify the new `#studio` section renders between plugins and the final CTA.
- [ ] Resize to mobile widths — cards stack; form input + button wrap cleanly.
- [ ] Submit form with a test email against a stubbed endpoint; confirm success state swaps in, and error JSON surfaces the `detail` field inline.
- [ ] Check prefers-color-scheme: dark — border/background contrast looks correct.
- [ ] Swap `NEWSLETTER_ENDPOINT` to the production Resend-proxy URL before launch; verify CORS allows `mycroft.buriedsignals.com`.