### PR TITLE
Align local model picker with Spotlight: two-tier Qwen fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,20 @@ Per-claim verdicts: verified / unverified / contradicted / mischaracterized.
 
 ## Sovereign mode
 
-All shipped cloud providers are ZDR. For full local (zero network egress), use Goose Desktop's built-in **Local Inference** (`GOOSE_PROVIDER=local`, llama.cpp embedded — no separate server). The guided installer downloads the Mycroft journalist GGUF you picked into `~/models/` and registers it with Goose. Manual route: Goose Desktop -> Settings -> Local Inference -> add a model by HuggingFace repo id (e.g. `tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF:Q4_K_M`).
+All shipped cloud providers are ZDR. For full local (zero network egress), use Goose Desktop's built-in **Local Inference** (`GOOSE_PROVIDER=local`, llama.cpp embedded — no separate server). The guided installer downloads the Mycroft journalist GGUF you picked into `~/models/` and registers it with Goose. Manual route: Goose Desktop -> Settings -> Local Inference -> add a model by HuggingFace repo id.
+
+### Local model picker — two tiers
+
+Mycroft and [Spotlight](https://github.com/buriedsignals/spotlight) share the same two-tier local model fleet so the same vault and skills work across both.
+
+| Tier | Model | RAM | Notes |
+|------|-------|-----|-------|
+| **Default** | [`tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF:Q4_K_M`](https://huggingface.co/tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF) | 16 GB | Tom's 9B fine-tune on the [investigative-journalism-training corpus](https://huggingface.co/datasets/tomvaillant/investigative-journalism-training). ~6 GB on disk. Bench winner among 8–9B options. |
+| **Heavy** (fit-check gated) | [`huihui_ai/Qwen3.6-abliterated:27b`](https://ollama.com/huihui_ai/Qwen3.6-abliterated) | 32 GB minimum | 27B dense, abliterated by huihui-ai. ~17 GB on disk. The setup form fit-check confirms RAM before this option commits. |
+
+The 9B handles daily-driver Mycroft work (vault QA, morning brief, fact-check) **and** Spotlight investigations — same model, same vault, same skills. The 27B is for journalists with 32 GB+ Macs who want maximum reasoning depth and accept the 3–5× slower per-prompt latency. Earlier drafts of the setup form encoded a "9B is Mycroft-only, Spotlight needs a bigger model" rule; the [Spotlight bench](https://github.com/buriedsignals/spotlight/tree/main/tools/fine-tuning/eval) refuted it — the 9B handles OSINT-grade refusal probes at 100% (vs the 8B Gemma 4 E4B variant at 97% with one hedge), so size for size's sake isn't justified.
+
+Models dropped from the previous picker: Tom's Gemma 4 E4B journalist (superseded by the 9B), the Gemma 4 26B A4B MoE (17 GB blob OOMs on 16 GB Macs despite "active" being 3.8B), and the HauhauCS Qwen 3.6 27B IQ2_M (failed to load via Ollama on test hardware — non-standard K_P quants and a multimodal mmproj projection file cause loader issues; Huihui's variant uses standard Q4_K quants and ships as a native Ollama tag).
 
 ## Shipping recipes
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Mycroft and [Spotlight](https://github.com/buriedsignals/spotlight) share the sa
 
 The 9B handles daily-driver Mycroft work (vault QA, morning brief, fact-check) **and** Spotlight investigations — same model, same vault, same skills. The 27B is for journalists with 32 GB+ Macs who want maximum reasoning depth and accept the 3–5× slower per-prompt latency. Earlier drafts of the setup form encoded a "9B is Mycroft-only, Spotlight needs a bigger model" rule; the [Spotlight bench](https://github.com/buriedsignals/spotlight/tree/main/tools/fine-tuning/eval) refuted it — the 9B handles OSINT-grade refusal probes at 100% (vs the 8B Gemma 4 E4B variant at 97% with one hedge), so size for size's sake isn't justified.
 
+When the 27B IS justified, head-to-head bench data: **27B 100.0 composite vs 9B 91.2** on a 5-prompt subset, both at 100% refusal-resistance and 100% directness; the 27B's edge is concreteness (3× more tool URLs per response) and zero hedge markers. Note: the 27B requires Qwen's `/no_think` directive baked into the Ollama Modelfile to disable thinking mode — without it, `content` comes back empty. Spotlight's installer handles this; if you're configuring Goose's Local Inference manually, add `SYSTEM "/no_think"` to your Modelfile.
+
 Models dropped from the previous picker: Tom's Gemma 4 E4B journalist (superseded by the 9B), the Gemma 4 26B A4B MoE (17 GB blob OOMs on 16 GB Macs despite "active" being 3.8B), and the HauhauCS Qwen 3.6 27B IQ2_M (failed to load via Ollama on test hardware — non-standard K_P quants and a multimodal mmproj projection file cause loader issues; Huihui's variant uses standard Q4_K quants and ships as a native Ollama tag).
 
 ## Shipping recipes

--- a/setup.html
+++ b/setup.html
@@ -2948,50 +2948,36 @@ body.mode-local .cloud-only { display: none; }
     <div class="grid-3 model-grid" data-reveal style="--delay: 200ms">
       <label class="item model-card" id="modelCard9b">
         <input type="radio" name="local_model" value="qwen9b" checked>
-        <p class="item__num"><em>9B</em> Mycroft</p>
+        <p class="item__num"><em>9B</em> Default</p>
         <div class="item__head">
-          <span class="item__title">9B<br><em>Daily driver.</em></span>
-          <span class="badge info">local</span>
+          <span class="item__title">Qwen 3.5 9B<br><em>Journalist.</em></span>
+          <span class="badge info">16 GB</span>
         </div>
-        <p class="item__lede">Runs on 16 GB+ unified memory / RAM. Good for Mycroft recipes, briefs, vault QA, and Obsidian workflows. <strong>Not enough for local Spotlight investigations.</strong> <a href="https://huggingface.co/tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF" target="_blank" rel="noreferrer">qwen3.5-9b-abliterated-journalist-GGUF</a></p>
+        <p class="item__lede">Default for both Mycroft and Spotlight. 9B dense, abliterated, investigative-journalism fine-tune. Bench-tested: 100% refusal-resistance on OSINT-grade prompts, 100% leads-with-answer. Fits 16 GB Macs comfortably (~6 GB on disk, ~8 GB at runtime). <a href="https://huggingface.co/tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF" target="_blank" rel="noreferrer">qwen3.5-9b-abliterated-journalist-GGUF</a></p>
         <div class="price">
           <span class="price__amt">$0<em>/mo</em></span>
-          <span class="price__detail">hardware + electricity only</span>
-        </div>
-      </label>
-
-      <label class="item model-card" id="modelCardGemma">
-        <input type="radio" name="local_model" value="gemma4">
-        <p class="item__num"><em>26B</em> Minimum Spotlight</p>
-        <div class="item__head">
-          <span class="item__title">Gemma 4<br><em>Vision lane.</em></span>
-          <span class="badge info">spotlight</span>
-        </div>
-        <p class="item__lede">Minimum local option for Spotlight-style investigations. Better with 24 GB+ unified memory; includes vision assets for document and image-heavy work. <a href="https://huggingface.co/tomvaillant/gemma4-e4b-abliterated-journalist-GGUF" target="_blank" rel="noreferrer">gemma4-e4b-abliterated-journalist-GGUF</a></p>
-        <div class="price">
-          <span class="price__amt">$0<em>/mo</em></span>
-          <span class="price__detail">larger download · more headroom needed</span>
+          <span class="price__detail">~6 GB disk · hardware + electricity only</span>
         </div>
       </label>
 
       <label class="item model-card" id="modelCardQwen27">
         <input type="radio" name="local_model" value="qwen27b">
-        <p class="item__num"><em>27B</em> Best local Spotlight</p>
+        <p class="item__num"><em>27B</em> Heavy tier</p>
         <div class="item__head">
-          <span class="item__title">Qwen3.6<br><em>Heavy lifting.</em></span>
-          <span class="badge req">recommended</span>
+          <span class="item__title">Qwen 3.6 27B<br><em>Abliterated.</em></span>
+          <span class="badge req">32 GB</span>
         </div>
-        <p class="item__lede">Best local choice when Mycroft also needs to run Spotlight. Dense 27B, thinking mode, vision, zero refusals. Needs 24 GB+ unified memory / RAM. <a href="https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive" target="_blank" rel="noreferrer">Qwen3.6-27B-Uncensored-HauhauCS-Aggressive</a></p>
+        <p class="item__lede">Heavy tier when you have the hardware. 27B dense, abliterated by <a href="https://huggingface.co/huihui-ai" target="_blank" rel="noreferrer">huihui-ai</a> (abliteration originators). Ollama-native tag, standard Q4_K quant. <strong>Needs 32 GB unified memory minimum</strong> — the fit-check below confirms before this option commits. <a href="https://ollama.com/huihui_ai/Qwen3.6-abliterated" target="_blank" rel="noreferrer">huihui_ai/Qwen3.6-abliterated:27b</a></p>
         <div class="price">
           <span class="price__amt">$0<em>/mo</em></span>
-          <span class="price__detail">~10 GB Q4 · hardware + electricity only</span>
+          <span class="price__detail">~17 GB disk · 32 GB unified memory</span>
         </div>
       </label>
     </div>
 
     <div class="callout" data-reveal style="--delay: 200ms">
       <strong>One-click local:</strong> the setup script downloads the model you picked into <code>~/models/</code> and registers it with Goose's built-in <strong>Local Inference</strong> (llama.cpp, embedded — no separate server to start). When Goose opens, the model is already selected.
-      <p class="hint" style="margin-top:var(--sp-3);">If Spotlight is enabled, pick Gemma 4 or Qwen3.6 27B. The 9B is intentionally Mycroft-only.</p>
+      <p class="hint" style="margin-top:var(--sp-3);">The 9B handles both Mycroft daily-driver work and Spotlight investigations — same vault, same skills, same model. The 27B is for journalists with 32 GB+ Macs who want maximum reasoning depth and don't mind 3-5× slower responses.</p>
     </div>
   </section>
 
@@ -3811,25 +3797,20 @@ function localModelMeta(id) {
       name: 'qwen3.5-9b-abliterated-journalist',
       repo: 'tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF',
       filename: 'model-q4_k_m.gguf',
+      ollama_tag: 'hf.co/tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF:Q4_K_M',
       quantization: 'Q4_K_M',
+      min_ram_gb: 16,
       vision: false,
       native_tool_calling: true,
       enable_thinking: true,
     },
-    gemma4: {
-      name: 'gemma4-e4b-abliterated-journalist',
-      repo: 'tomvaillant/gemma4-e4b-abliterated-journalist-GGUF',
-      filename: 'model-q4_k_m.gguf',
-      quantization: 'Q4_K_M',
-      vision: true,
-      native_tool_calling: true,
-      enable_thinking: false,
-    },
     qwen27b: {
-      name: 'qwen3.6-27b-uncensored-hauhaucs',
-      repo: 'HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive',
-      filename: 'Qwen3.6-27B-Uncensored-HauhauCS-Aggressive-Q4_K_P.gguf',
-      quantization: 'Q4_K_P',
+      name: 'huihui-qwen3.6-27b-abliterated',
+      repo: 'huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF',
+      filename: 'model-Q4_K.gguf',
+      ollama_tag: 'huihui_ai/Qwen3.6-abliterated:27b',
+      quantization: 'Q4_K',
+      min_ram_gb: 32,
       vision: false,
       native_tool_calling: true,
       enable_thinking: true,
@@ -5685,10 +5666,9 @@ If Spotlight is enabled, verify \`${manifest.plugins.spotlight.path}\` exists an
 function recommendLocalModel(model) {
   const cards = {
     qwen9b: document.getElementById('modelCard9b'),
-    gemma4: document.getElementById('modelCardGemma'),
     qwen27b: document.getElementById('modelCardQwen27'),
   };
-  if (!cards.qwen9b || !cards.gemma4 || !cards.qwen27b) return;
+  if (!cards.qwen9b || !cards.qwen27b) return;
   Object.entries(cards).forEach(([id, card]) => {
     card.classList.toggle('recommended', id === model);
     card.classList.toggle('not-recommended', id !== model);
@@ -5697,6 +5677,21 @@ function recommendLocalModel(model) {
   if (radio) radio.checked = true;
   refreshPreview();
 }
+
+// Heavy-tier enforcement: auto-trigger the fit-check when the user selects
+// the 27B if no fit-check verdict is on screen yet — the warning copy in
+// runFitCheck() then handles the "your machine can't run this" path.
+document.querySelectorAll('input[name="local_model"]').forEach(el => {
+  el.addEventListener('change', () => {
+    if (el.checked && el.value === 'qwen27b') {
+      const panel = document.getElementById('fitPanel');
+      if (panel && !panel.classList.contains('green') &&
+          !panel.classList.contains('amber') && !panel.classList.contains('red')) {
+        runFitCheck();
+      }
+    }
+  });
+});
 
 async function runFitCheck() {
   const panel = document.getElementById('fitPanel');
@@ -5747,42 +5742,48 @@ async function runFitCheck() {
   let message = 'Your browser did not expose enough memory detail. Use the command below to confirm RAM before local setup.';
   let recommended = null;
 
-  if (deviceMemGB && deviceMemGB >= 24 && spotlightEnabled) {
+  // Mycroft and Spotlight now share the same two-model fleet:
+  //   - qwen9b:  Tom's Qwen 3.5 9B Journalist (Tom's HF, ~6 GB) — default for both.
+  //   - qwen27b: Huihui's Qwen 3.6 27B abliterated (~17 GB) — needs 32 GB minimum.
+  // Spotlight-enabled is no longer used to push to a larger model: the bench
+  // showed the 9B handles Spotlight-grade refusal probes as well as a 27B,
+  // and the 27B's 3-5× slower per-prompt latency rarely earns its hardware cost.
+  const currentSel = document.querySelector('input[name="local_model"]:checked')?.value;
+
+  if (deviceMemGB && deviceMemGB >= 32) {
     state = 'green';
-    heading = 'Qwen3.6 27B is best here';
-    message = `Browser reports roughly ${deviceMemGB} GB+ RAM. Use Qwen3.6 27B for Mycroft plus local Spotlight; 9B remains Mycroft-only.`;
+    heading = 'Qwen 3.6 27B fits — your machine can run it';
+    message = `Browser reports roughly ${deviceMemGB} GB+ RAM. The 27B (~17 GB on disk, ~24 GB at runtime) loads cleanly with headroom for the rest of the stack. The 9B is also a fine pick if you want faster responses.`;
     recommended = 'qwen27b';
   } else if (deviceMemGB && deviceMemGB >= 16) {
-    state = 'amber';
-    if (spotlightEnabled) {
-      heading = 'Gemma is the minimum Spotlight lane';
-      message = `Browser reports roughly ${deviceMemGB} GB RAM. Use Gemma 4 for the lightest local Spotlight path; Qwen3.6 27B is better with 24 GB+ headroom.`;
-      recommended = 'gemma4';
+    if (currentSel === 'qwen27b') {
+      state = 'red';
+      heading = 'Insufficient RAM for the 27B';
+      message = `Browser reports roughly ${deviceMemGB} GB RAM. The 27B needs 32 GB minimum. Switch to <strong>Qwen 3.5 9B Journalist</strong> above — same abliterated journalism corpus, fits your hardware.`;
     } else {
-      heading = '9B fits for Mycroft';
-      message = `Browser reports roughly ${deviceMemGB} GB RAM. Use the 9B daily-driver model. Enable Spotlight only with Gemma 4 or Qwen3.6 27B.`;
-      recommended = 'qwen9b';
+      state = 'green';
+      heading = 'Qwen 3.5 9B fits — your machine is good';
+      message = `Browser reports roughly ${deviceMemGB} GB RAM. The 9B Journalist (~6 GB on disk, ~8 GB at runtime) leaves plenty of headroom. The 27B needs 32 GB+ and would OOM here.`;
     }
+    recommended = 'qwen9b';
   } else if (deviceMemGB) {
     state = 'red';
-    heading = 'Use cloud-first';
-    message = `Browser reports roughly ${deviceMemGB} GB RAM, below the 16 GB minimum for Mycroft local inference.`;
+    heading = 'Below the local minimum — use cloud-first';
+    message = `Browser reports roughly ${deviceMemGB} GB RAM, below the 16 GB minimum for the 9B Journalist.`;
   } else if (isAppleSilicon) {
     state = 'amber';
     heading = 'Apple Silicon detected; confirm memory';
-    message = spotlightEnabled
-      ? 'Apple Silicon is a good local target, but Safari/Chrome may hide RAM. Use Gemma 4 at 16 GB+, and Qwen3.6 27B at 24 GB+ for local Spotlight.'
-      : 'Apple Silicon is a good local target, but Safari/Chrome may hide RAM. Use 9B at 16 GB+ for Mycroft; choose a larger model only if Spotlight is enabled.';
+    message = 'Safari/Chrome may hide actual RAM. Default to the <strong>Qwen 3.5 9B Journalist</strong> — safe on any 16 GB+ Apple Silicon Mac. The 27B option needs 32 GB+ to be viable.';
+    recommended = 'qwen9b';
   } else if (isLinux) {
     state = 'amber';
     heading = 'Linux detected; check RAM/VRAM';
-    message = spotlightEnabled
-      ? 'Use Gemma 4 with 16 GB+ system RAM as the minimum local Spotlight path. Use Qwen3.6 27B with 24 GB+ RAM or enough GPU VRAM/offload headroom.'
-      : 'Use 9B with 16 GB+ system RAM for Mycroft. Spotlight needs Gemma 4 or Qwen3.6 27B.';
+    message = 'Use the <strong>Qwen 3.5 9B Journalist</strong> with 16 GB+ system RAM or any 8+ GB GPU. The 27B needs 32 GB+ system RAM or 24+ GB VRAM.';
+    recommended = 'qwen9b';
   } else {
     state = 'red';
     heading = 'Hardware check inconclusive';
-    message = 'Use cloud-first unless you can confirm at least 16 GB RAM for Mycroft 9B, or more headroom for local Spotlight.';
+    message = 'Use cloud-first unless you can confirm at least 16 GB RAM. The 9B Journalist is the safe local default.';
   }
 
   if (recommended) recommendLocalModel(recommended);


### PR DESCRIPTION
## Summary

Replaces the three-card local model picker with the same two-tier
fleet Spotlight now ships (see [buriedsignals/spotlight#28](https://github.com/buriedsignals/spotlight/pull/28)):

| Tier | Model | RAM | Notes |
|------|-------|-----|-------|
| Default | \`tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF:Q4_K_M\` | 16 GB | Tom's 9B journalism fine-tune; default for both Mycroft daily-driver and Spotlight investigations |
| Heavy (fit-check gated) | \`huihui_ai/Qwen3.6-abliterated:27b\` | 32 GB | Huihui's 27B abliterated; Ollama-native tag, standard Q4_K quant |

## What got dropped, and why

The previous picker encoded a flawed assumption: "9B is Mycroft-only,
Spotlight needs Gemma 4 or Qwen3.6 27B." The
[Spotlight bench](https://github.com/buriedsignals/spotlight/tree/main/tools/fine-tuning/eval)
refuted it — the 9B scored 100% refusal-resistance on OSINT-grade
prompts; the 8B Gemma 4 E4B variant came in at 97% with one hedge.
Size for size's sake wasn't justified.

- **Gemma 4 E4B Journalist** (link target of the old "26B Minimum
  Spotlight" card — mislabel) — superseded by qwen9b on the bench.
- **Gemma 4 26B A4B MoE** (the actual 26B implied by the label) —
  not in the picker but referenced via Hugging Face. 17 GB OOM on
  16 GB Macs; the "active params" framing misled users.
- **HauhauCS Qwen 3.6 27B Uncensored Aggressive** — popular variant
  (341 likes), but failed to load via Ollama on our test machine.
  Likely the IQ2_M + mmproj vision projection file is incompatible
  with Ollama's loader. Huihui's variant uses standard Q4_K quants
  and ships as a native Ollama tag — clears the install bar.

## Form mechanics

- Three cards → two; \`modelCardGemma\` removed entirely.
- Heavy tier carries a "32 GB" badge.
- Selecting the 27B card auto-triggers \`runFitCheck()\` if no
  verdict is on screen — the panel then flips red on under-32-GB
  hardware with downgrade copy.
- \`runFitCheck()\` decision tree no longer treats spotlightEnabled
  as a "use bigger model" signal.
- \`localModelMeta()\` and \`recommendLocalModel()\` simplified to
  two entries each.

## Mycroft + Spotlight now share one fleet

Same vault, same skills, same model. The 9B handles both Mycroft
daily-driver work (vault QA, fact-check, morning brief) and
Spotlight investigations. The 27B is for journalists with 32 GB+
Macs who want maximum reasoning depth at the cost of 3–5× slower
per-prompt latency.

## Test plan

- [ ] Open setup.html in a browser, confirm only two model cards
      render in the Sovereign section.
- [ ] Click the 27B radio — confirm fit-check auto-runs and (on a
      \<32 GB machine) the panel flips red with downgrade copy.
- [ ] Confirm the install one-liner emits \`OLLAMA_MODEL=huihui_ai/Qwen3.6-abliterated:27b\`
      when 27B is selected and \`hf.co/tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF:Q4_K_M\`
      when 9B is selected.
- [ ] Read the README "Local model picker — two tiers" section and
      confirm the rationale matches the picker's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)