### PR TITLE
Fix Pages deploy: guard top-level DOM call, sync 27B test asserts

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -5688,17 +5688,21 @@ function recommendLocalModel(model) {
 // Heavy-tier enforcement: auto-trigger the fit-check when the user selects
 // the 27B if no fit-check verdict is on screen yet — the warning copy in
 // runFitCheck() then handles the "your machine can't run this" path.
-document.querySelectorAll('input[name="local_model"]').forEach(el => {
-  el.addEventListener('change', () => {
-    if (el.checked && el.value === 'qwen27b') {
-      const panel = document.getElementById('fitPanel');
-      if (panel && !panel.classList.contains('green') &&
-          !panel.classList.contains('amber') && !panel.classList.contains('red')) {
-        runFitCheck();
+// Guarded so the validate workflow can extract these helpers into a Node
+// vm context (no `document`) without blowing up at import time.
+if (typeof document !== 'undefined') {
+  document.querySelectorAll('input[name="local_model"]').forEach(el => {
+    el.addEventListener('change', () => {
+      if (el.checked && el.value === 'qwen27b') {
+        const panel = document.getElementById('fitPanel');
+        if (panel && !panel.classList.contains('green') &&
+            !panel.classList.contains('amber') && !panel.classList.contains('red')) {
+          runFitCheck();
+        }
       }
-    }
+    });
   });
-});
+}
 
 async function runFitCheck() {
   const panel = document.getElementById('fitPanel');

--- a/tests/setup-generator-check.js
+++ b/tests/setup-generator-check.js
@@ -142,10 +142,10 @@ if (syntax.status !== 0) {
   process.exit(syntax.status || 1);
 }
 assertIncludes(localScript, "GOOSE_PROVIDER=local");
-assertIncludes(localScript, "GOOSE_MODEL=HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive:Q4_K_P");
-assertIncludes(localScript, "MYCROFT_LOCAL_MODEL_REPO=HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive");
-assertIncludes(localScript, "MYCROFT_LOCAL_MODEL_FILE=Qwen3.6-27B-Uncensored-HauhauCS-Aggressive-Q4_K_P.gguf");
-assertIncludes(localScript, "MYCROFT_LOCAL_MODEL_QUANT=Q4_K_P");
+assertIncludes(localScript, "GOOSE_MODEL=huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF:Q4_K");
+assertIncludes(localScript, "MYCROFT_LOCAL_MODEL_REPO=huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF");
+assertIncludes(localScript, "MYCROFT_LOCAL_MODEL_FILE=model-Q4_K.gguf");
+assertIncludes(localScript, "MYCROFT_LOCAL_MODEL_QUANT=Q4_K");
 assertIncludes(localScript, "install_local_model");
 assertIncludes(localScript, "register_local_model_in_goose");
 assertIncludes(localScript, "$XDG_DATA_HOME/goose/models");


### PR DESCRIPTION
## Summary

The Pages deploy ([run #26332551418](https://github.com/buriedsignals/mycroft/actions/runs/26332551418/job/77520901203)) failed in the `validate` job after merging PR #27. Two independent breakages:

1. **PR #27 broke `tests/setup-generator-check.js`.** The test extracts the JS between `function shq(s)` and `\nfunction refreshPreview()` from `setup.html` and runs it in a Node `vm` context. PR #27 added a top-level `document.querySelectorAll('input[name="local_model"]').forEach(...)` in that range, which crashed with `ReferenceError: document is not defined` because the vm context has no DOM. Fix: guard the listener registration with `if (typeof document !== 'undefined')`.

2. **PR #26 left stale 27B asserts.** PR #26 swapped the 27B picker from `HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive` to `huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF` (install reliability — HauhauCS's IQ2_M + mmproj caused Ollama load failures). But `tests/setup-generator-check.js` was never updated and still asserted the HauhauCS repo / filename / quant. Surfaced only after fixing breakage #1. Fix: update the four 27B asserts to match the new huihui-ai picker.

## Test plan

- [x] `node tests/setup-generator-check.js` → `setup generator: OK`
- [x] `python3 tools/validate-recipes.py` → 28 OK / 0 failed
- [x] `python3 tests/grounding-provenance-check.py` → OK
- [ ] CI `validate` job green on this PR
- [ ] After merge: Pages deploy succeeds on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)