### PR TITLE
Bump Pages workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,8 +18,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install PyYAML
@@ -56,10 +56,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v6
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: "."
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

GitHub deprecation warning on the last deploy: Node 20 actions forced to Node 24 by default on **June 2, 2026**; Node 20 removed from runners on **Sept 16, 2026**. Bumping all five actions in `.github/workflows/pages.yml` to their current Node-24 majors so we stop seeing the annotation and don't surprise-break later.

| Action | Old | New | Runtime |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | node24 |
| `actions/setup-python` | v5 | v6 | node24 |
| `actions/configure-pages` | v5 | v6 | node24 |
| `actions/upload-pages-artifact` | v3 | v5 | composite → `upload-artifact@v7` |
| `actions/deploy-pages` | v4 | v5 | node24 |

Each `using:` field was verified against the `action.yml` at the pinned tag — no `node20` left anywhere in the chain.

## Test plan

- [ ] CI deploy runs on merge to main and finishes green
- [ ] Pages annotation about "Node.js 20 actions are deprecated" is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)