### PR TITLE
Make Mycroft fact-check provenance-first by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
   paths.
 
 ### Changed
+- `recipes/fact-check.yaml` is now provenance-first by default for
+  fact-checking: it instructs agents to use `mycroft-fetch`, emit evidence and
+  SIFT manifests, and build an unsigned provenance manifest when available.
+  Provenance failures are reported as incomplete but non-blocking unless
+  `strict_provenance=true`; live Noosphere/C2PA signing remains opt-in with
+  `c2pa_sign=true`.
 - **BREAKING — `fact-check/SKILL.md` output contract.** Every claim now
   requires a 7-field `grounding` object (support_type, source_role,
   claim_elements_checked, missing_assumptions, confidence_cap,

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ goose run --recipe ~/.local/share/goose/mycroft/source/recipes/fact-check.yaml \
 ```
 
 Per-claim verdicts: verified / unverified / contradicted / mischaracterized.
+The default fact-check path is provenance-first: it tries to capture evidence
+with `mycroft-fetch`, write source hashes, and build an unsigned provenance
+package. This is not a hard dependency for quick editorial review unless you
+pass `--params strict_provenance=true`. Live Noosphere/C2PA signing remains
+opt-in with `--params c2pa_sign=true`.
 
 ## Sovereign mode
 
@@ -142,7 +147,7 @@ Models dropped from the previous picker: Tom's Gemma 4 E4B journalist (supersede
 
 **Core journalism:**
 - `vault-qa` — vault + web Q&A with citations
-- `fact-check` — SIFT, per-claim verdicts
+- `fact-check` — SIFT, per-claim verdicts, default provenance package when available
 - `qmd` — local markdown search over Mycroft and Spotlight vaults
 - `source-verify` — SIFT against a single source's credibility
 - `start` — first-run menu for setting up a beat, adding material, creating a morning brief, investigating a lead, setting up scouts, or generating a demo

--- a/docs/grounding-provenance-spec.md
+++ b/docs/grounding-provenance-spec.md
@@ -8,8 +8,9 @@ Spotlight grounding/C2PA work while keeping Mycroft focused on durable newsroom
 knowledge and draft verification.
 
 Scope is deliberate: this spec applies to the **fact-check** profile
-of the `epistemic-grounding` skill (the `fact-check` skill and the
-`fact-check-c2pa.yaml` recipe). Routine Mycroft skills — `morning-brief`,
+of the `epistemic-grounding` skill (the `fact-check` skill, the default
+`fact-check.yaml` recipe, and the compatibility `fact-check-c2pa.yaml` recipe).
+Routine Mycroft skills — `morning-brief`,
 `vault-qa`, `obsidian-ingest`, `source-monitor`, `content-creator` — use the
 **default** profile: the ladder and confidence caps applied in-head plus
 the lighter `confidence:` tag from `SOUL.md`. See
@@ -126,6 +127,12 @@ Required top-level files for a fact-check package:
 - `data/sift-manifest.json`
 - `data/provenance-manifest.json`
 
+The default `fact-check.yaml` recipe should attempt to create these files for
+every fact-check. This is a default, not a mandatory gate: quick editorial
+fact-checking may continue with `provenance incomplete` reported when local
+tooling is unavailable. `strict_provenance=true` turns provenance failures into
+blocking failures. Noosphere/C2PA signing remains opt-in.
+
 The existing `sift-manifest-v1` should be revised to:
 
 - require 64-character SHA-256 hashes,
@@ -233,10 +240,13 @@ review.
    - recomputed file-hash checks.
 
 4. Update recipes:
-   - `fact-check-c2pa.yaml` should use evidence bundle IDs, not free-form
-     provenance IDs only,
+   - `fact-check.yaml` should use `mycroft-fetch`, emit manifests by default,
+     and continue with a visible warning when provenance fails unless
+     `strict_provenance=true`,
+   - `fact-check-c2pa.yaml` remains a compatibility explicit-C2PA route and
+     should use evidence bundle IDs, not free-form provenance IDs only,
    - keep C2PA signing opt-in,
-   - fail clearly when `mycroft-fetch` is missing.
+   - report clearly when `mycroft-fetch` is missing.
 
 5. Add manifest builder:
    - build unsigned package manifests locally,

--- a/recipes/fact-check.yaml
+++ b/recipes/fact-check.yaml
@@ -1,12 +1,19 @@
 version: "1.0.0"
-title: "Fact-check (SIFT)"
-description: "Run SIFT methodology against a draft article. Returns per-claim verdicts with cited sources."
+title: "Fact-check (SIFT + provenance)"
+description: "Run SIFT methodology against a draft article. Returns per-claim verdicts with cited sources and a provenance package when available."
 
 instructions: |
   Load the Mycroft journalism instructions (ethics, SIFT, no fabrication) as session context.
   Load ~/.mycroft/skills/fact-check/SKILL.md before checking claims.
   Apply SIFT rigorously; each factual claim gets a specific verdict, never a vague hedge.
   Do not rewrite the draft; do not moralise. Report, let the journalist decide.
+  Provenance is default but not mandatory: attempt evidence capture, validation,
+  and manifest generation for every fact-check, but do not fail the fact-check
+  unless strict provenance is requested.
+
+  IMPORTANT: Use `mycroft-fetch` instead of raw `firecrawl` for web fetches.
+  This captures evidence records (URL, local artifact, SHA-256 hash, timestamp)
+  for grounding and optional C2PA package signing.
 
 parameters:
   - key: draft_path
@@ -19,14 +26,29 @@ parameters:
     requirement: optional
     description: "Draft text inline (use when draft is short and pastable)"
     default: ""
+  - key: emit_manifest
+    input_type: boolean
+    requirement: optional
+    description: "Emit evidence, SIFT, and provenance manifests when possible"
+    default: true
+  - key: strict_provenance
+    input_type: boolean
+    requirement: optional
+    description: "Fail the fact-check if provenance validation or manifest generation fails"
+    default: false
+  - key: c2pa_sign
+    input_type: boolean
+    requirement: optional
+    description: "Automatically sign via Noosphere/C2PA signer when configured"
+    default: false
 
 extensions:
   - type: builtin
     name: developer
-    description: "Shell + file access — reads the draft, invokes firecrawl CLI for verification"
+    description: "Shell + file access — reads the draft, invokes mycroft-fetch for verification with provenance capture"
 
 prompt: |
-  SIFT fact-check.
+  SIFT fact-check with default provenance capture.
 
   Apply the SIFT framework:
     - **S**top — don't accept claims at face value
@@ -58,31 +80,183 @@ prompt: |
      - **contradicted** — a more authoritative source disagrees (cite the contradiction explicitly)
      - **mischaracterized** — source exists but the claim misrepresents it (cite original + explain the gap)
 
-  4. Use the firecrawl CLI for verification:
-     - `firecrawl search "query"` for discovery
-     - `firecrawl scrape <url>` for specific pages
-     - Never use WebFetch, curl, or any other browser tool.
+  4. Use `mycroft-fetch` for web verification whenever it is available:
+     - `mycroft-fetch search "query"` for discovery
+     - `mycroft-fetch scrape <url>` for specific pages
+     - This captures evidence IDs, source URLs, timestamps, local artifact paths, and SHA-256 hashes.
+     - Never use WebFetch, curl, raw firecrawl, or any other browser tool for normal fetches.
+     - If `mycroft-fetch` is unavailable, continue only if the fact-check can still be cited clearly; report "provenance incomplete: mycroft-fetch unavailable".
 
   5. Output as a markdown table:
 
-     | # | Claim | Verdict | Primary source | Notes |
-     |---|-------|---------|----------------|-------|
-     | 1 | ... | verified | https://... | ... |
+     | # | Claim | Verdict | Primary source | Evidence ID | Grounding | Notes |
+     |---|-------|---------|----------------|-------------|-----------|-------|
+     | 1 | ... | verified | https://... | E-xxx | direct/full | ... |
 
   6. End with a summary block:
      - Verdict counts (verified / partially / unverified / contradicted / mischaracterized)
      - Claims needing additional reporting (list with specific next steps)
      - Strongest-supported claim(s)
      - Weakest/most-at-risk claim(s)
+     - Provenance status:
+       - `created` when evidence bundle, SIFT manifest, and provenance manifest exist
+       - `incomplete` when fetch, validation, or manifest generation failed
+       - `unsigned` when package exists and C2PA signing was not requested
+       - `signed` when the signer returns a receipt
+       - `signing_failed` when signing fails but the unsigned package remains usable
+
+  {% if emit_manifest %}
+  7. After the summary, create a fact-check package directory and save:
+
+     - `data/evidence-bundle.json`
+     - `data/sift-manifest.json`
+     - `data/provenance-manifest.json` when the manifest build succeeds
+
+     Evidence bundle shape:
+
+     ```json
+     {
+       "schema_version": "1.0",
+       "project": "<draft slug or project>",
+       "run_id": "<optional run id>",
+       "created_at": "<ISO timestamp>",
+       "items": [
+         {
+           "id": "E-xxx",
+           "source_url": "<source URL>",
+           "acquisition_method": "firecrawl",
+           "accessed_at": "<from mycroft-fetch>",
+           "raw_path": "<from mycroft-fetch>",
+           "sha256": "<64 lowercase hex from mycroft-fetch>",
+           "content_type": "text/markdown",
+           "access_method": "full_text",
+           "archive_url": "<Wayback/Archive.today URL if created>",
+           "human_verification_required": false,
+           "claim_links": [
+             {
+               "claim_id": "claim-001",
+               "claim_text": "<claim text>",
+               "support_type": "direct"
+             }
+           ],
+           "missing_source_gate": {
+             "requested_source": "<what you needed>",
+             "returned_artifact": "<raw_path>",
+             "missing": "",
+             "fallback_required": false,
+             "confidence_effect": "none"
+           }
+         }
+       ]
+     }
+     ```
+
+     SIFT manifest shape:
+
+     ```json
+     {
+       "schema": "sift-manifest-v1",
+       "timestamp": "<ISO timestamp>",
+       "investigator": {
+         "name": "<your name from MYCROFT_USER_NAME or 'Mycroft'>",
+         "organization": "<from MYCROFT_ORG or empty>"
+       },
+       "draft": {
+         "path": "{{ draft_path }}",
+         "content_hash": "sha256:<hash of draft content>",
+         "title": "<extracted or inferred title>"
+       },
+       "claims": [
+         {
+           "id": "claim-001",
+           "text": "<claim text>",
+           "verdict": "<verdict>",
+           "confidence": "high|medium|low",
+           "evidence_refs": ["E-xxx", "E-yyy"],
+           "sources": ["E-xxx", "E-yyy"],
+           "grounding": {
+             "support_type": "direct|indirect|inferred|contradicted|insufficient",
+             "source_role": "primary|secondary|contextual",
+             "claim_elements_checked": ["actor", "action", "date"],
+             "missing_assumptions": [],
+             "confidence_cap": "high|medium|low",
+             "misgrounding_risk": "<short risk statement>",
+             "assessment": "<why evidence does or does not ground the claim; include contradiction-search outcome>"
+           },
+           "human_review": "unreviewed",
+           "notes": "<optional notes>"
+         }
+       ],
+       "sources": [
+         {
+           "id": "E-xxx",
+           "evidence_id": "E-xxx",
+           "url": "<source URL>",
+           "content_hash": "sha256:<64 lowercase hex from mycroft-fetch>",
+           "access_timestamp": "<from mycroft-fetch>",
+           "access_type": "full",
+           "sift_step": "trace_to_original",
+           "is_primary": true,
+           "title": "<human-readable title>"
+         }
+       ],
+       "summary": {
+         "verified": <count>,
+         "partially_verified": <count>,
+         "unverified": <count>,
+         "contradicted": <count>,
+         "mischaracterized": <count>,
+         "total_claims": <count>,
+         "total_sources": <count>
+       },
+       "methodology": {
+         "name": "SIFT",
+         "version": "1.0",
+         "vault_searched": true,
+         "web_searched": true
+       }
+     }
+     ```
+
+     Then run:
+
+     ```bash
+     python3 "$MYCROFT_DIR/tools/validate-grounding.py" <package-dir> --strict-files
+     python3 "$MYCROFT_DIR/tools/build-provenance-manifest.py" <package-dir>
+     ```
+
+     If provenance validation or manifest generation fails, continue the fact-check unless `strict_provenance` is true. Preserve the markdown verdict table and report:
+     - exact command that failed
+     - short error
+     - "provenance incomplete"
+     - whether claim verdicts remain usable as cited, unsigned editorial review output
+
+     If `strict_provenance` is true, stop and report the provenance failure before presenting the fact-check as complete.
+  {% endif %}
+
+  {% if c2pa_sign %}
+  8. C2PA signing is optional and off by default. If signing is requested, call the configured Noosphere/C2PA signer only after local validation succeeds:
+
+     ```bash
+     python3 "$MYCROFT_DIR/tools/build-provenance-manifest.py" <package-dir> \
+       --sign-endpoint "${NOOSPHERE_C2PA_URL:-http://localhost:5002/api/mycroft/provenance/sign}" \
+       --credential-id "${NOOSPHERE_C2PA_CREDENTIAL_ID:-}" \
+       --artifact review.md
+     ```
+
+     If signing fails, keep the unsigned provenance package and report `signing_failed`. Do not say C2PA proves the claims are true; say the package is tamper-evident if signing succeeds.
+  {% endif %}
 
   Rules:
   - Do not rewrite the draft.
   - Do not moralise.
   - If you cannot verify a claim and cannot find a contradiction, verdict is `unverified` — that is not a failure, it is the correct verdict.
   - Never fabricate sources.
+  - Always try to use mycroft-fetch for provenance tracking in fact-checking.
+  - Do not make C2PA signing a requirement unless the user explicitly asks for signing or strict provenance.
 
 activities:
-  - "message: **SIFT fact-check ready.** Paste a draft or point to a file. I'll return per-claim verdicts."
+  - "message: **SIFT fact-check ready.** Paste a draft or point to a file. I'll return per-claim verdicts with provenance when available."
   - "Fact-check my latest draft"
   - "Verify just the numeric claims in this draft"
   - "Re-run after I update the sources"

--- a/skills/fact-check/SKILL.md
+++ b/skills/fact-check/SKILL.md
@@ -16,7 +16,9 @@ Load this skill before answering fact-checking requests. Do not rely on general 
 
 ## Default Path
 
-Use the Mycroft recipe first:
+Use the Mycroft recipe first. The default fact-check path attempts provenance
+capture and unsigned manifest generation for every run, but it does not require
+Noosphere/C2PA signing.
 
 ```sh
 goose run --recipe ~/.local/share/goose/mycroft/source/recipes/fact-check.yaml --params draft_path="<path>"
@@ -27,6 +29,11 @@ If the user provides short pasted text instead of a file:
 ```sh
 goose run --recipe ~/.local/share/goose/mycroft/source/recipes/fact-check.yaml --params draft_text="<text>"
 ```
+
+For newsroom workflows where provenance must be complete before delivery, pass
+`strict_provenance=true`. To request live Noosphere/C2PA signing, pass
+`c2pa_sign=true`; signing remains opt-in and fact-check verdicts remain
+editorial outputs, not C2PA truth claims.
 
 ## Spotlight Escalation
 
@@ -45,7 +52,7 @@ Use Spotlight for deeper casework. Keep the fact-checker independent from the in
 Apply the `epistemic-grounding` skill (claim decomposition, support classification, confidence caps, failure router) to every claim. This skill adds three fact-check-specific moves:
 
 1. **Local context first.** Check Mycroft and Spotlight QMD collections before any web fetch — surface what's already known, link to it, don't re-verify.
-2. **SIFT acquisition.** Stop, investigate the source, find better coverage, trace to origin. Acquire evidence via `mycroft-fetch` (preferred) or firecrawl through the `shell-safety` pattern. Every acquisition produces an evidence item — `mycroft-fetch` records URL, acquisition method, accessed_at, sha256 of saved bytes, content_type, access_method, and the missing-source gate. See `docs/grounding-provenance-spec.md`.
+2. **SIFT acquisition.** Stop, investigate the source, find better coverage, trace to origin. Acquire evidence via `mycroft-fetch` first. Every acquisition should produce an evidence item: `mycroft-fetch` records URL, acquisition method, accessed_at, sha256 of saved bytes, content_type, access_method, and the missing-source gate. If provenance tooling is unavailable, continue the fact-check only as a cited editorial review output and report `provenance incomplete` unless `strict_provenance=true`. See `docs/grounding-provenance-spec.md`.
 3. **Verdict mapping.** Translate the grounding analysis to the closed verdict set (below) and emit the output contract.
 
 ## Required Output Contract

--- a/tests/fact-check-recipe-contract.py
+++ b/tests/fact-check-recipe-contract.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Contract checks for the default Mycroft fact-check recipe."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RECIPE = ROOT / "recipes/fact-check.yaml"
+
+
+def parameter_default(recipe: str, key: str) -> str:
+    match = re.search(
+        rf"- key: {re.escape(key)}\n(?:(?:    .*\n)*?)    default: ([^\n]+)",
+        recipe,
+    )
+    if not match:
+        raise AssertionError(f"missing parameter default for {key}")
+    return match.group(1).strip()
+
+
+def main() -> int:
+    recipe = RECIPE.read_text(encoding="utf-8")
+
+    assert "mycroft-fetch" in recipe, "default fact-checking must capture provenance through mycroft-fetch"
+    assert "firecrawl CLI for verification" not in recipe, "default fact-checking must not point agents at raw firecrawl"
+    assert parameter_default(recipe, "emit_manifest") == "true"
+    assert parameter_default(recipe, "strict_provenance") == "false"
+    assert parameter_default(recipe, "c2pa_sign") == "false"
+    assert "Provenance is default but not mandatory" in recipe
+    assert "If provenance validation or manifest generation fails" in recipe
+    assert "continue the fact-check unless `strict_provenance` is true" in recipe
+    assert "C2PA signing is optional and off by default" in recipe
+    assert "build-provenance-manifest.py" in recipe
+    assert "NOOSPHERE_C2PA_URL" in recipe
+
+    print("fact-check recipe contract: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Make the default Mycroft fact-check recipe use mycroft-fetch and attempt evidence/SIFT/provenance manifests by default
- Keep Noosphere/C2PA signing opt-in with c2pa_sign=false and add strict_provenance for workflows that should fail on provenance errors
- Update fact-check skill/docs/changelog and add a recipe contract regression test

## Test plan
- python3 tests/fact-check-recipe-contract.py
- python3 tests/grounding-provenance-check.py
- python3 tests/shell-safety-check.py
- node tests/setup-generator-check.js