### PR TITLE
feat(scoutpost): Mycroft Scoutpost — CLI-or-API only, remove MCP

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -69,8 +69,8 @@
       "repo": "https://github.com/buriedsignals/scoutpost-os",
       "status": "launching with Mycroft",
       "selectable_default": true,
-      "mode": "hosted_api",
-      "api_base": "https://www.scoutpost.ai/api/v1",
+      "mode": "cli_or_api",
+      "api_base": "https://scoutpost.ai/functions/v1",
       "env": ["SCOUTPOST_API_KEY"]
     },
     {

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,70 @@ ensure_qmd() {
   if have npm; then npm install -g @tobilu/qmd && ok "QMD CLI"; else warn "npm missing; install QMD manually with: npm install -g @tobilu/qmd"; fi
 }
 
+# --- Scoutpost CLI (scout) ---------------------------------------------------
+# `scout` on PATH via npm, pinned to the vendored catalog.json (native-binary-via-
+# npm, like firecrawl/qmd). CLI branch = macOS/Linux/WSL2 with npm; a host without
+# npm/scout falls back to the REST API (SCOUTPOST_API_KEY + SCOUTPOST_API_BASE). The
+# public Supabase anon key is baked (identical to the engine's constant) — it is not
+# a per-user secret, so there is no form field to collect it.
+SCOUTPOST_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdmbWR6aXBsdGljZm9ha2hyZnB0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njc2MDYzMjIsImV4cCI6MjA4MzE4MjMyMn0.Liz22BqK2qfHBcIsIJxGTT4VvMzfBE_yRFraVrUPKq4"
+
+# Read the scoutpost-cli pin from the vendored catalog.json. New logic — no other
+# installer idiom reads catalog.json; python3 is a hard prerequisite of this script.
+scout_cli_pin() {
+  local catalog="$MYCROFT_DIR/catalog/catalog.json"
+  [ -f "$catalog" ] || return 0
+  python3 - "$catalog" <<'PIN_PY' 2>/dev/null
+import json, sys
+try:
+    print(json.load(open(sys.argv[1])).get("dependencies", {}).get("scoutpost-cli", ""))
+except Exception:
+    pass
+PIN_PY
+}
+
+install_scout_cli() {
+  [ "$ENABLE_SCOUTPOST" = "1" ] || return 0
+  if have scout; then ok "scout CLI present"; return 0; fi
+  if ! have npm && [ "$(uname -s)" = "Darwin" ]; then ensure_brew && brew install node; fi
+  if ! have npm; then
+    warn "npm missing; Scoutpost will use the REST API. To enable the scout CLI later: npm install -g scoutpost-cli"
+    return 0
+  fi
+  local pin; pin="$(scout_cli_pin)"
+  if [ -n "$pin" ]; then
+    npm install -g "scoutpost-cli@$pin" && ok "scout CLI ($pin)" || warn "scout CLI install failed; Scoutpost will use the REST API."
+  else
+    npm install -g scoutpost-cli && ok "scout CLI (unpinned — no catalog pin found)" || warn "scout CLI install failed; Scoutpost will use the REST API."
+  fi
+}
+
+# Write ~/.scoutpost/config.json for the scout CLI (functions/v1 + baked public anon
+# key + cj_ api_key), 0600, via a direct write with xtrace disabled so the key never
+# enters a trace — never `scout config set` (that puts the key in argv). CLI branch
+# only; the REST branch reads SCOUTPOST_API_KEY from the profile .env.
+write_scout_config() {
+  [ "$ENABLE_SCOUTPOST" = "1" ] || return 0
+  have scout || return 0
+  [ -n "${SCOUTPOST_API_KEY:-}" ] || { warn "Scoutpost enabled but no API key found; skipping scout config."; return 0; }
+  local cfg="$HOME/.scoutpost/config.json" oldumask xtrace=0
+  mkdir -p "$HOME/.scoutpost"; chmod 700 "$HOME/.scoutpost" 2>/dev/null || true
+  case "$-" in *x*) xtrace=1; set +x;; esac
+  oldumask="$(umask)"; umask 077
+  cat > "$cfg" <<SCOUT_CFG_EOF
+{
+  "api_url": "https://scoutpost.ai/functions/v1",
+  "supabase_anon_key": "$SCOUTPOST_ANON_KEY",
+  "api_key": "$SCOUTPOST_API_KEY"
+}
+SCOUT_CFG_EOF
+  chmod 600 "$cfg"
+  umask "$oldumask"
+  [ "$xtrace" = 1 ] && set -x
+  ok "scout config (~/.scoutpost/config.json)"
+}
+# -----------------------------------------------------------------------------
+
 configure_qmd() {
   if ! have qmd; then warn "QMD CLI missing; vault search and Spotlight query-vault will be unavailable until qmd is installed."; return 0; fi
   qmd collection add "$VAULT_PATH" --name mycroft >/dev/null 2>&1 || true
@@ -203,10 +267,9 @@ install_mycroft_cli() {
 
 install_skill_registry() {
   mkdir -p "$MYCROFT_PROFILE_SKILLS_DIR" "$MYCROFT_SKILLS_DIR"
-  if [ "$ENABLE_SCOUTPOST" = "1" ] && have curl; then
-    mkdir -p "$MYCROFT_PROFILE_SKILLS_DIR/scoutpost"
-    curl -fsSL https://scoutpost.ai/skills/scoutpost.md -o "$MYCROFT_PROFILE_SKILLS_DIR/scoutpost/SKILL.md" || cp "$MYCROFT_SKILLS_DIR/scoutpost/SKILL.md" "$MYCROFT_PROFILE_SKILLS_DIR/scoutpost/SKILL.md" || warn "Using bundled Scoutpost skill; hosted product skill could not be fetched."
-  fi
+  # Scoutpost ships the authored, CLI/API-only skill from the repo (skills/scoutpost),
+  # placed by the manifest loop below. No hosted-skill fetch — the hosted product skill
+  # names MCP as a surface, and Mycroft is CLI-or-API only.
   if [ ! -f "$MYCROFT_SKILL_REGISTRY" ]; then
     warn "Missing $MYCROFT_SKILL_REGISTRY — the configurator did not finish; re-run the installer."
     exit 1
@@ -232,9 +295,6 @@ install_skill_registry() {
       [ -d "$skill_dir" ] || continue
       ln -sfn "$skill_dir" "$HOME/.agents/skills/mycroft/$(basename "$skill_dir")"
     done
-  fi
-  if [ "$ENABLE_SCOUTPOST" = "1" ] && [ -d "$MYCROFT_PROFILE_SKILLS_DIR/scoutpost" ]; then
-    ln -sfn "$MYCROFT_PROFILE_SKILLS_DIR/scoutpost" "$HOME/.agents/skills/mycroft/scoutpost"
   fi
   ok "Mycroft skill registry"
 }
@@ -318,7 +378,7 @@ GOOSE_SPOTLIGHT_EOF
 ## Scoutpost Installed Context
 
 Scoutpost is enabled. Use the installed Scoutpost skill from the Mycroft skill registry.
-Prefer MCP if configured, then the scout CLI if installed, then the hosted API with SCOUTPOST_API_KEY and SCOUTPOST_API_BASE.
+Prefer the scout CLI if installed, otherwise the hosted API with SCOUTPOST_API_KEY and SCOUTPOST_API_BASE. Do not use MCP.
 Never print the API key.
 GOOSE_SCOUTPOST_EOF
   fi
@@ -515,6 +575,10 @@ configure_goose_persistent_defaults() {
   store_goose_secret FIRECRAWL_API_KEY "${FIRECRAWL_API_KEY:-}"
   store_goose_secret SCOUTPOST_API_KEY "${SCOUTPOST_API_KEY:-}"
   store_goose_secret OSINT_NAV_API_KEY "${OSINT_NAV_API_KEY:-}"
+
+  # Scoutpost CLI config (if `scout` is installed): ~/.scoutpost/config.json from the
+  # just-sourced key. REST-only hosts skip this and use SCOUTPOST_API_KEY from .env.
+  write_scout_config
 
   ok "Goose default provider config"
 }
@@ -1019,6 +1083,7 @@ INSTALL_CRAWL4AI="$INSTALL_CRAWL4AI" INSTALL_SEARXNG="$INSTALL_SEARXNG" INSTALL_
 # ...then the optional Firecrawl escape hatch (gated, off by default).
 install_firecrawl
 ensure_qmd
+install_scout_cli
 install_mycroft_cli
 sync_mycroft_profile
 seed_mycroft_vault
@@ -1442,7 +1507,7 @@ PROFILE_SPOTLIGHT_EOF
 ## Scoutpost Installed Context
 
 Scoutpost is enabled. Use the installed Scoutpost skill from the Mycroft skill registry.
-Prefer MCP if configured, then the scout CLI if installed, then the hosted API with SCOUTPOST_API_KEY and SCOUTPOST_API_BASE.
+Prefer the scout CLI if installed, otherwise the hosted API with SCOUTPOST_API_KEY and SCOUTPOST_API_BASE. Do not use MCP.
 Never print the API key.
 PROFILE_SCOUTPOST_EOF
     fi

--- a/install/setup_server.py
+++ b/install/setup_server.py
@@ -30,6 +30,11 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 SUBMIT_TIMEOUT_SECONDS = 30 * 60
 
+# Public Supabase anon key for hosted Scoutpost (functions/v1). Not a secret — it is
+# baked into the engine binary and the SPA; sent as the `apikey:` header alongside the
+# cj_ bearer token, which the Edge Functions front door requires.
+SCOUTPOST_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdmbWR6aXBsdGljZm9ha2hyZnB0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njc2MDYzMjIsImV4cCI6MjA4MzE4MjMyMn0.Liz22BqK2qfHBcIsIJxGTT4VvMzfBE_yRFraVrUPKq4"
+
 
 def detect_platform():
     """mac | linux | windows-wsl — the page preselects matching path defaults."""
@@ -165,8 +170,9 @@ def validate_keys(d, skip=False):
                        {"Authorization": "Bearer " + d["fireworksKey"]}))
     if d.get("scoutpost") and d.get("scoutpostKey"):
         checks.append(("scoutpost_api_key", "SCOUTPOST_API_KEY", False,
-                       "https://www.scoutpost.ai/api/v1/scouts",
-                       {"Authorization": "Bearer " + d["scoutpostKey"]}))
+                       "https://scoutpost.ai/functions/v1/scouts",
+                       {"Authorization": "Bearer " + d["scoutpostKey"],
+                        "apikey": SCOUTPOST_ANON_KEY}))
     for field, name, strict, url, headers in checks:
         result = probe(url, headers)
         if result == "rejected" and strict:
@@ -223,7 +229,8 @@ def build_env_lines(d):
             lines.append(f"{name}={shlex.quote(d[key])}")
     if d.get("scoutpost") and d.get("scoutpostKey"):
         lines.append("SCOUTPOST_API_KEY=" + shlex.quote(d["scoutpostKey"]))
-        lines.append("SCOUTPOST_API_BASE=https://www.scoutpost.ai/api/v1")
+        lines.append("SCOUTPOST_API_BASE=https://scoutpost.ai/functions/v1")
+        lines.append("SCOUTPOST_SUPABASE_ANON_KEY=" + shlex.quote(SCOUTPOST_ANON_KEY))
     if d.get("spotlight"):
         lines.append('SPOTLIGHT_DIR="$MYCROFT_PLUGINS_DIR/spotlight"')
         lines.append(f'SPOTLIGHT_VAULT_PATH="{spotlight_vault}"')
@@ -308,7 +315,7 @@ def build_skill_registry(d):
             entry["status"] = SKILL_STATUS[sid]
         skills.append(entry)
     if d.get("scoutpost"):
-        skills.append({"id": "scoutpost", "path": "~/.config/goose/mycroft/skills/scoutpost/SKILL.md", "source": "mycroft-profile", "enabled": True, "product_skill_url": "https://scoutpost.ai/skills/scoutpost.md"})
+        skills.append({"id": "scoutpost", "path": "~/.agents/skills/mycroft/scoutpost/SKILL.md", "source": "mycroft-repo", "enabled": True, "product_skill_url": "https://scoutpost.ai/skills/scoutpost.md"})
     if d.get("spotlight"):
         skills += [
             {"id": "spotlight", "path": "~/.local/share/goose/mycroft/plugins/spotlight/skills/spotlight/SKILL.md", "source": "spotlight", "enabled": True},

--- a/skills/scoutpost/SKILL.md
+++ b/skills/scoutpost/SKILL.md
@@ -1,34 +1,35 @@
 ---
 name: scoutpost
-description: Hosted Scoutpost API integration for scouts, monitoring requests, and beat signals.
+description: Scoutpost integration for scouts, monitoring, and beat signals via the scout CLI or REST API.
 ---
 
 # Scoutpost
 
-Use this skill when Scoutpost was enabled in Mycroft setup.
+Use this skill when Scoutpost was enabled in Mycroft setup. Scoutpost is a monitoring platform for journalists: scheduled scouts watch pages, beats, social profiles, and councils, and extract source-linked information units.
+
+## Surfaces (in order)
+
+Mycroft talks to Scoutpost over **two** surfaces — never MCP:
+
+1. **`scout` CLI** — if the `scout` binary is on `$PATH`, prefer it. Commands stay visible in the transcript. Its config lives at `~/.scoutpost/config.json`.
+2. **REST API** — if `scout` is not installed (for example a host with no CLI build), call the hosted API directly.
+
+If neither is available, explain what is missing and offer to configure it.
 
 ## Configuration
 
-Read:
+- **CLI:** `~/.scoutpost/config.json` (`api_url`, `supabase_anon_key`, `api_key`) is written by the installer. Run `scout` directly; never print the key.
+- **REST:** read `SCOUTPOST_API_KEY` from Goose's secret store or the fallback `~/.config/goose/mycroft/.env`. Call `https://scoutpost.ai/functions/v1`. Send the key as `Authorization: Bearer cj_…` **and** the public anon key as the `apikey:` header — the Edge Functions front door rejects bare bearer tokens.
 
-- `SCOUTPOST_API_KEY` from Goose's secret store or fallback `~/.config/goose/mycroft/.env`
-- `SCOUTPOST_API_BASE`, default `https://www.scoutpost.ai/api/v1`
+## Usage semantics
 
-The product skill source is:
+The canonical, product-maintained guide — scout types, verification policy, credit rules — is the hosted product skill:
 
 ```text
 https://scoutpost.ai/skills/scoutpost.md
 ```
 
-If the installed skill differs from the hosted product skill, prefer the hosted product skill when available.
-
-## Capability Order
-
-1. Use a Goose-compatible Scoutpost MCP server if it is installed and configured.
-2. Use a `scout` CLI if present.
-3. Use the hosted API directly with the configured API key.
-
-If none are available, explain what is missing and offer to configure it.
+Read it for how to operate scouts correctly. This file governs only *which surfaces* Mycroft uses (CLI or REST — not MCP).
 
 ## Use Cases
 
@@ -41,4 +42,6 @@ If none are available, explain what is missing and offer to configure it.
 
 - Never print the API key.
 - Do not send confidential source identities unless the user explicitly approves.
+- Confirm before creating or running anything that spends credits.
+- Treat unverified units as leads, not publishable facts; always include source URLs when summarizing.
 - Store durable scout findings in Mycroft, not Spotlight, unless they are part of an active case.


### PR DESCRIPTION
Makes Mycroft's Scoutpost integration offer only the **scout CLI** (when on PATH) and the **REST API** — never MCP. No MCP server was ever installed by either install path; the MCP "surfaces" were inert instruction text, now removed.

## Changes

- **U1 — skill** (`skills/scoutpost/SKILL.md`): capability order `scout CLI (if present) → REST API`, MCP tier dropped, hosted product skill referenced by URL for usage semantics only.
- **U5 — strip MCP text** (`install.sh`): removed the hosted-skill `curl`-overwrite (which re-injected the MCP-inclusive product skill), and rewrote the two `.goosehints`/profile `"Prefer MCP if configured…"` lines. The authored repo skill is placed via the existing manifest symlink loop.
- **U3 — CLI provisioning** (`install.sh`, `install/setup_server.py`): install `scoutpost-cli@<catalog pin>` on macOS/Linux/WSL2 with npm, and write `~/.scoutpost/config.json` (`functions/v1` + baked public anon key + `cj_` api_key, `0600`, direct write — never `scout config set`). `setup_server.py` validates against `functions/v1` with `Bearer`+`apikey` (non-blocking) and provisions the REST fallback env. No-npm hosts use the REST API via the portable `.env`. Windows is served via WSL2 (full CLI path); native Windows is a non-goal.

## Verification

- `bash -n install.sh` and `py_compile setup_server.py` pass.
- All 8 `tests/setup-server-check.py` tests pass.
- Exercised the novel logic: catalog pin reads `0.1.7`; `write_scout_config` produces valid JSON with correct fields at `-rw-------`.
- `grep` confirms zero MCP surface instructions remain in the changed files.

## Follow-up (not in this PR)

**U6** — engine catalog version bump + `SPEC.md` scout-mcp reconcile → re-vendor `catalog.json`/`skills.manifest` → `extensions/manifest.json` mode. Blocked on the engine repo landing its WIP on `main`; will be added to this branch or land as a follow-up.

Plan: `engine/docs/plans/2026-07-08-001-refactor-scoutpost-cli-api-only-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)