### PR TITLE
docs: README hero header + expanded acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
+<div align="center">
+
 # Mycroft
+
+### Goose extension pack for investigative journalists
+
+**Newsroom memory, recurring editorial workflows, and source-grounded fact-checking — 16 skills, 27 recipes, open-weight and local-capable, ZDR cloud optional.**
+
+[Install](#install) | [First Run](#first-run) | [Core Workflows](#core-workflows) | [Recipes](#shipping-recipes) | [Website](https://mycroft.buriedsignals.com/)
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-00c853?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)[![16 Skills](https://img.shields.io/badge/skills-16-0080ff?style=for-the-badge&logo=bookstack&logoColor=white)](https://github.com/buriedsignals/mycroft/tree/main/skills)[![27 Recipes](https://img.shields.io/badge/recipes-27-ff6d00?style=for-the-badge&logo=windowsterminal&logoColor=white)](https://github.com/buriedsignals/mycroft/tree/main/recipes)[![Privacy](https://img.shields.io/badge/privacy-local_or_ZDR_cloud-00bfa5?style=for-the-badge&logo=shield&logoColor=white)](#privacy-and-providers)
+
+[![Stars](https://img.shields.io/github/stars/buriedsignals/mycroft?style=flat-square&logo=github&label=Stars)](https://github.com/buriedsignals/mycroft/stargazers)[![Issues](https://img.shields.io/github/issues/buriedsignals/mycroft?style=flat-square&logo=github&label=Issues)](https://github.com/buriedsignals/mycroft/issues)[![Last Commit](https://img.shields.io/github/last-commit/buriedsignals/mycroft?style=flat-square&logo=github&label=Last%20Commit)](https://github.com/buriedsignals/mycroft/commits)[![Contributors](https://img.shields.io/github/contributors/buriedsignals/mycroft?style=flat-square&logo=github&label=Contributors)](https://github.com/buriedsignals/mycroft/graphs/contributors)
+
+Built by [**Buried Signals**](https://buriedsignals.com/) • [tom@buriedsignals.com](mailto:tom@buriedsignals.com)
+
+</div>
+
+---
 
 Mycroft is a Goose extension pack for newsroom memory, recurring editorial
 workflows, source-grounded fact-checking, and handoffs between monitoring,
@@ -245,6 +263,25 @@ when a lead needs active investigation. Use Scoutpost when something should be
 monitored over time.
 
 ## Acknowledgements
+
+Mycroft stands on open work — community-maintained open-source projects and
+open methods. A sincere thank-you to every project below — the pack would not
+exist without them. *(Listing does not imply affiliation or endorsement.)*
+
+| Category | Projects we're grateful to |
+|----------|----------------------------|
+| **Agent runtime** | [Goose](https://github.com/block/goose) (Block, Apache-2.0 — the open-source runtime Mycroft is built on) |
+| **Journalism skills & methods** | [claude-skills-journalism](https://github.com/jamditis/claude-skills-journalism) (Joe Amditis, MIT) · [SIFT](https://hapgood.us/2019/06/19/sift-the-four-moves/) (Mike Caulfield) |
+| **Sovereign search & scraping** | [SearXNG](https://github.com/searxng/searxng) (AGPL-3.0) · [Crawl4AI](https://github.com/unclecode/crawl4ai) (unclecode, Apache-2.0) · [Playwright](https://playwright.dev/) (browser automation) · [Poppler](https://poppler.freedesktop.org/) (`pdftotext` — PDF extraction) · [Tor](https://www.torproject.org/) (opt-in anonymous scraping) |
+| **Local inference** | [llama.cpp](https://github.com/ggml-org/llama.cpp) (ggml, MIT) |
+| **Media & metadata** | [ExifTool](https://exiftool.org/) (Phil Harvey — powers photo-metadata) |
+| **Knowledge vault** | [Obsidian](https://obsidian.md/) (the vault app) · [QMD](https://www.npmjs.com/package/@tobilu/qmd) (tobilu — local vault search) |
+| **Provenance** | [C2PA](https://c2pa.org/) (content-provenance standard behind SIFT manifests) |
+
+> Built something here we should credit, or want a listing changed or removed?
+> Open an issue or PR — we'll fix it fast.
+
+### Vendored skills
 
 Five of Mycroft's journalism skills — `foia-requests`, `interview-prep`,
 `story-pitch`, `photo-metadata`, and `ai-writing-detox` — are adapted from

--- a/index.html
+++ b/index.html
@@ -3106,6 +3106,14 @@ html.js .is-in .tw__in {
       <li><a href="https://hapgood.us/2019/06/19/sift-the-four-moves/" target="_blank" rel="noreferrer">Mike Caulfield</a> <span>— the SIFT verification method</span></li>
       <li><a href="https://exiftool.org/" target="_blank" rel="noreferrer">exiftool</a> <span>— Phil Harvey · powers photo-metadata</span></li>
       <li><a href="https://www.npmjs.com/package/@tobilu/qmd" target="_blank" rel="noreferrer">QMD</a> <span>— tobilu · local vault search</span></li>
+      <li><a href="https://github.com/searxng/searxng" target="_blank" rel="noreferrer">SearXNG</a> <span>— self-hosted search behind sovereign mode · AGPL</span></li>
+      <li><a href="https://github.com/unclecode/crawl4ai" target="_blank" rel="noreferrer">Crawl4AI</a> <span>— unclecode · the sovereign scraper</span></li>
+      <li><a href="https://playwright.dev/" target="_blank" rel="noreferrer">Playwright</a> <span>— browser automation under the scraper</span></li>
+      <li><a href="https://poppler.freedesktop.org/" target="_blank" rel="noreferrer">Poppler</a> <span>— pdftotext · PDF extraction</span></li>
+      <li><a href="https://github.com/ggml-org/llama.cpp" target="_blank" rel="noreferrer">llama.cpp</a> <span>— ggml · local inference inside Goose</span></li>
+      <li><a href="https://www.torproject.org/" target="_blank" rel="noreferrer">Tor Project</a> <span>— opt-in anonymous scraping</span></li>
+      <li><a href="https://obsidian.md/" target="_blank" rel="noreferrer">Obsidian</a> <span>— the knowledge vault</span></li>
+      <li><a href="https://c2pa.org/" target="_blank" rel="noreferrer">C2PA</a> <span>— content-provenance standard behind SIFT manifests</span></li>
     </ul>
   </section>
 


### PR DESCRIPTION
## What

- **README**: centered hero header (tagline, nav links, shields.io badges — MIT license, 16 skills, 27 recipes, privacy mode, plus live GitHub stats) and a categorized acknowledgements table.
- **index.html**: acknowledgements list grows from 5 to 13 entries — adds SearXNG, Crawl4AI, Playwright, Poppler, llama.cpp, Tor, Obsidian, and C2PA, matching the existing list style.

## Why

The site and README credited only 5 projects while the sovereign search/scrape stack, local inference, vault tooling, and provenance standard went unacknowledged. Scope is limited to community-maintained, operationally load-bearing projects (plus Goose and Obsidian); commercial services and framework plumbing are deliberately excluded. Vendored-skills attribution (Amditis / NOTICE.md) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)