### PR TITLE
site: enrich acknowledgements (Whisper, Edge TTS) + fix Pages deploy test

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ exist without them. *(Listing does not imply affiliation or endorsement.)*
 | **Sovereign search & scraping** | [SearXNG](https://github.com/searxng/searxng) (AGPL-3.0) · [Crawl4AI](https://github.com/unclecode/crawl4ai) (unclecode, Apache-2.0) · [Playwright](https://playwright.dev/) (browser automation) · [Poppler](https://poppler.freedesktop.org/) (`pdftotext` — PDF extraction) · [Tor](https://www.torproject.org/) (opt-in anonymous scraping) |
 | **Local inference** | [llama.cpp](https://github.com/ggml-org/llama.cpp) (ggml, MIT) |
 | **Media & metadata** | [ExifTool](https://exiftool.org/) (Phil Harvey — powers photo-metadata) |
+| **Voice** | [Whisper](https://github.com/openai/whisper) (MIT — open-weight local dictation) · [Edge TTS](https://github.com/rany2/edge-tts) (rany2, LGPL-3.0 — spoken briefings) |
 | **Knowledge vault** | [Obsidian](https://obsidian.md/) (the vault app) · [QMD](https://www.npmjs.com/package/@tobilu/qmd) (tobilu — local vault search) |
 | **Provenance** | [C2PA](https://c2pa.org/) (content-provenance standard behind SIFT manifests) |
 

--- a/index.html
+++ b/index.html
@@ -3112,6 +3112,8 @@ html.js .is-in .tw__in {
       <li><a href="https://poppler.freedesktop.org/" target="_blank" rel="noreferrer">Poppler</a> <span>— pdftotext · PDF extraction</span></li>
       <li><a href="https://github.com/ggml-org/llama.cpp" target="_blank" rel="noreferrer">llama.cpp</a> <span>— ggml · local inference inside Goose</span></li>
       <li><a href="https://www.torproject.org/" target="_blank" rel="noreferrer">Tor Project</a> <span>— opt-in anonymous scraping</span></li>
+      <li><a href="https://github.com/openai/whisper" target="_blank" rel="noreferrer">Whisper</a> <span>— open-weight local dictation</span></li>
+      <li><a href="https://github.com/rany2/edge-tts" target="_blank" rel="noreferrer">Edge TTS</a> <span>— rany2 · spoken briefings</span></li>
       <li><a href="https://obsidian.md/" target="_blank" rel="noreferrer">Obsidian</a> <span>— the knowledge vault</span></li>
       <li><a href="https://c2pa.org/" target="_blank" rel="noreferrer">C2PA</a> <span>— content-provenance standard behind SIFT manifests</span></li>
     </ul>

--- a/tests/setup-server-check.py
+++ b/tests/setup-server-check.py
@@ -114,7 +114,7 @@ class UnitChecks(unittest.TestCase):
         reg = srv.build_skill_registry(srv.normalize(BASE))
         ids = {s["id"] for s in reg["skills"]}
         for expected in ["knowledge-primitives", "qmd", "obsidian", "obsidian-ingest",
-                         "fact-check", "mycroft-maintenance", "firecrawl", "scoutpost",
+                         "fact-check", "mycroft-maintenance", "web-acquisition", "scoutpost",
                          "spotlight", "spotlight-ingest", "spotlight-monitoring",
                          "spotlight-integrations"]:
             self.assertIn(expected, ids)


### PR DESCRIPTION
## What

- **Fixes the Pages deploy**: `tests/setup-server-check.py` still expected a `firecrawl` skill in the registry; the sovereign migration renamed it `web-acquisition`, so the `validate` job (and therefore the Pages deploy) has failed on the last two main commits — the live site is stuck on the old 5-entry acknowledgements list. Test suite passes locally after the fix.
- **index.html**: adds Whisper (open-weight local dictation) and Edge TTS (rany2 — spoken briefings) to the acknowledgements list (now 15 entries).
- **README**: adds a Voice row to the acknowledgements table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)