### PR TITLE
fix: make OpenKnowledge the canonical public install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ that can run with ZDR cloud models or local inference.
 
 ## What Mycroft Does
 
-- Maintains an Obsidian-compatible journalism vault for sources, notes, methods,
+- Maintains an OpenKnowledge journalism workspace for sources, notes, methods,
   story material, and handoffs.
 - Ingests links, PDFs, newsletters, pasted notes, documents, and folders into
   structured local knowledge.
@@ -47,7 +47,7 @@ that can run with ZDR cloud models or local inference.
 |---|---|---|
 | Start | First-run menu for beats, knowledge ingest, morning brief, scouts, lead investigation, or demo flow. | `start` |
 | Vault Q&A | Answers questions over local newsroom memory and live sources with citations. | `vault-qa` |
-| Knowledge ingest | Turns links, notes, files, PDFs, folders, and newsletters into structured vault material. | `vault-sync`, `obsidian-ingest`, `newsletter-summarize` |
+| Knowledge ingest | Turns links, notes, files, PDFs, folders, and newsletters into structured knowledge. | `vault-sync`, `newsletter-summarize` |
 | Fact-check | Checks article drafts or claims with SIFT-style verdicts and optional provenance packaging. | `fact-check` |
 | Source verification | Evaluates a single source's credibility and evidence value. | `source-verify` |
 | Morning brief | Builds a recurring digest from configured beats, watchlists, AgentMail, bookmarks, and recent vault changes. | `morning-brief` |
@@ -119,8 +119,8 @@ exports/
 _schema/
 ```
 
-QMD indexes both vaults when Spotlight is enabled, so agents can search prior
-work without flattening casework into published knowledge.
+OpenKnowledge indexes both workspaces when Spotlight is enabled, so agents can
+search prior work without flattening casework into published knowledge.
 
 ## Install
 
@@ -131,10 +131,9 @@ curl -fsSL https://mycroft.buriedsignals.com/install.sh | bash
 ```
 
 One static, reviewable script ([`install.sh`](install.sh)) for every install.
-It surfaces exactly the skills listed in [`skills.manifest`](skills.manifest) — the
-engine-resolved set for the Goose runtime (`bsig skills resolve`; the engine catalog is the
-source of truth) — into `~/.agents/skills/mycroft/`. Regenerate the manifest when the catalog
-changes. The script also fetches this repo, then opens a local configurator page in the browser —
+Engine resolves each selected skill once into `~/.ok/skills/<name>` and projects
+the flat name into Goose's discovery directory. The script also fetches this
+repo, then opens a local configurator page in the browser —
 served from `127.0.0.1` by `install/setup_server.py`. Sovereignty preference,
 provider keys, plugins, and vault paths (with a native folder picker) are all
 collected there; keys are verified live with each provider and written straight
@@ -145,8 +144,8 @@ Prefer a file? The hosted setup page offers a ZIP whose `install.command`
 fetches and runs the same canonical script. When the install finishes, open a
 new terminal so shell configuration changes take effect.
 
-The installer configures Goose, provider files, recipe discovery, vault paths,
-QMD indexing, Mycroft instructions, updater recipes, scheduled workflows, and
+The installer configures Goose, OpenKnowledge, provider files, recipe discovery,
+workspace paths, Mycroft instructions, updater recipes, scheduled workflows, and
 the first-run menu. Architecture details live in
 [docs/architecture.md](docs/architecture.md).
 
@@ -178,7 +177,7 @@ cp ~/.local/share/goose/mycroft/source/instructions/mycroft-soul.md ~/.config/go
 cp ~/.local/share/goose/mycroft/source/instructions/journalism.md ~/.config/goose/.goosehints
 ```
 
-Use the guided installer for normal use; it also handles QMD, schedules, updater
+Use the guided installer for normal use; it also handles OpenKnowledge search, schedules, updater
 state, generated instructions, and first-run files.
 
 ## Privacy And Providers
@@ -276,7 +275,7 @@ exist without them. *(Listing does not imply affiliation or endorsement.)*
 | **Local inference** | [llama.cpp](https://github.com/ggml-org/llama.cpp) (ggml, MIT) |
 | **Media & metadata** | [ExifTool](https://exiftool.org/) (Phil Harvey — powers photo-metadata) |
 | **Voice** | [Whisper](https://github.com/openai/whisper) (MIT — open-weight local dictation) · [Edge TTS](https://github.com/rany2/edge-tts) (rany2, LGPL-3.0 — spoken briefings) |
-| **Knowledge vault** | [Obsidian](https://obsidian.md/) (the vault app) · [QMD](https://www.npmjs.com/package/@tobilu/qmd) (tobilu — local vault search) |
+| **Knowledge workspace** | [OpenKnowledge](https://github.com/inkeep/open-knowledge) (local knowledge app, CLI, search, and agent workspace) |
 | **Provenance** | [C2PA](https://c2pa.org/) (content-provenance standard behind SIFT manifests) |
 
 > Built something here we should credit, or want a listing changed or removed?

--- a/install.sh
+++ b/install.sh
@@ -1072,6 +1072,12 @@ warn_legacy_layout
 ensure_git
 install_or_update_mycroft
 
+if ! have bsig; then
+  warn "Buried Signals Engine (bsig) is required for the public OpenKnowledge installer."
+  warn "Install/open the Indicator Labs desktop app, or install the signed bsig standalone release, then re-run Mycroft."
+  exit 1
+fi
+
 PREFLIGHT_HELPER="$MYCROFT_DIR/scripts/install-preflight.sh"
 if [ ! -f "$PREFLIGHT_HELPER" ]; then
   warn "Installer preflight helper missing: $PREFLIGHT_HELPER"
@@ -1094,10 +1100,9 @@ if [ -f "$MYCROFT_PROFILE_DIR/engine-plan.ready" ]; then
   printf '✓ Engine wrote a sealed Mycroft plan. Review and apply the plan path shown in the browser with: bsig apply <plan-path>\n'
   exit 0
 fi
-if [ ! -f "$MYCROFT_SETUP_CONFIG" ]; then
-  warn "Configuration was not completed; re-run the installer to try again."
-  exit 1
-fi
+warn "Engine did not produce a sealed plan; no legacy Obsidian/QMD fallback was applied."
+warn "Run 'bsig auth login' if Navigator is enabled, then re-run the installer."
+exit 1
 set -a
 . "$MYCROFT_SETUP_CONFIG"
 set +a

--- a/tests/install-sh-check.sh
+++ b/tests/install-sh-check.sh
@@ -30,7 +30,9 @@ includes 'GOOSE_RECIPE_PATH_VALUE="$MYCROFT_DIR/recipes:$MYCROFT_GENERATED_RECIP
 # Configurator phase: bootstrap fetches repo, local server collects config
 includes 'python3 "$MYCROFT_DIR/install/setup_server.py" --profile-dir "$MYCROFT_PROFILE_DIR" --repo-dir "$MYCROFT_DIR"'
 includes 'MYCROFT_SETUP_CONFIG="$MYCROFT_PROFILE_DIR/setup-config.env"'
-includes '. "$MYCROFT_SETUP_CONFIG"'
+includes 'if ! have bsig; then'
+includes 'if [ -f "$MYCROFT_PROFILE_DIR/engine-plan.ready" ]; then'
+includes 'no legacy Obsidian/QMD fallback was applied'
 # No keys or choices baked into the script itself
 excludes '__CFG__'
 excludes 'ENV_EOF'


### PR DESCRIPTION
## Summary
- require Engine for public installs and fail closed instead of silently running the Obsidian/QMD writer
- document the flat OpenKnowledge skill registry and workspace model
- retain a clear Navigator login repair path

## Verification
- install contract and setup-server suites
- installer preflight and static contract suites
- shell syntax