### PR TITLE
fix(mycroft): retire configurator fallback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1095,8 +1095,10 @@ fi
 say "Opening the Mycroft configurator in your browser"
 echo "  Your choices and API keys go to a local server on 127.0.0.1 only and are"
 echo "  written to $MYCROFT_PROFILE_DIR — nothing is uploaded anywhere."
+ENGINE_PLAN_MARKER="$MYCROFT_PROFILE_DIR/engine-plan.ready"
+rm -f "$ENGINE_PLAN_MARKER"
 python3 "$MYCROFT_DIR/install/setup_server.py" --profile-dir "$MYCROFT_PROFILE_DIR" --repo-dir "$MYCROFT_DIR"
-if [ -f "$MYCROFT_PROFILE_DIR/engine-plan.ready" ]; then
+if [ -f "$ENGINE_PLAN_MARKER" ]; then
   printf '✓ Engine wrote a sealed Mycroft plan. Review and apply the plan path shown in the browser with: bsig apply <plan-path>\n'
   exit 0
 fi

--- a/install/engine_bridge.py
+++ b/install/engine_bridge.py
@@ -2,13 +2,13 @@
 
 No provider/model catalog or normalization lives here. Engine describes and
 validates the form, Keychain receives secret values over stdin, and Engine
-writes the reviewable sealed plan. The legacy configurator remains a fallback
-only when a compatible `bsig` is not installed.
+writes the reviewable sealed plan. There is no legacy writer fallback.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from typing import Any
@@ -21,7 +21,7 @@ class EngineUnavailable(RuntimeError):
 class EngineBridge:
     def __init__(self, product: str):
         self.product = product
-        self.binary = shutil.which("bsig")
+        self.binary = os.environ.get("BSIG_BINARY") or shutil.which("bsig")
         if not self.binary:
             raise EngineUnavailable("bsig is not installed")
 
@@ -30,6 +30,8 @@ class EngineBridge:
             result = subprocess.run([self.binary, *args], input=stdin, capture_output=True, timeout=timeout, check=False)
         except subprocess.TimeoutExpired as error:
             raise EngineUnavailable("Engine did not resolve its signed catalog in time") from error
+        except OSError as error:
+            raise EngineUnavailable("Engine could not be started") from error
         events = []
         for line in result.stdout.decode("utf-8", "replace").splitlines():
             try:

--- a/install/setup_server.py
+++ b/install/setup_server.py
@@ -575,9 +575,9 @@ def main():
     try:
         engine_bridge = EngineBridge("mycroft")
         engine_descriptor = engine_bridge.descriptor()
-    except (EngineUnavailable, RuntimeError, KeyError):
-        engine_bridge = None
-        engine_descriptor = None
+    except (EngineUnavailable, RuntimeError, KeyError) as error:
+        print(f"A compatible Buried Signals Engine is required: {error}", file=sys.stderr)
+        return 1
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, *_):
@@ -606,7 +606,10 @@ def main():
                 self._send(404, "not found", "text/plain")
 
         def do_POST(self):
-            if self.path not in ("/submit", "/pick-folder", "/engine-submit"):
+            if self.path == "/submit":
+                self._send(410, json.dumps({"errors":[{"field":"","message":"The legacy writer is retired; submit through Engine."}]}))
+                return
+            if self.path not in ("/pick-folder", "/engine-submit"):
                 self._send(404, "not found", "text/plain")
                 return
             try:
@@ -623,8 +626,6 @@ def main():
                 self._send(200, json.dumps({"path": path, "error": error}))
                 return
             if self.path == "/engine-submit":
-                if engine_bridge is None:
-                    self._send(409, json.dumps({"errors":[{"field":"","message":"A compatible Engine descriptor is unavailable; reload to use the legacy installer."}]})); return
                 try:
                     response = engine_bridge.submit(payload.get("request") or {}, payload.get("secrets") or {})
                     marker = os.path.join(args.profile_dir, "engine-plan.ready")

--- a/tests/install-sh-check.sh
+++ b/tests/install-sh-check.sh
@@ -31,8 +31,10 @@ includes 'GOOSE_RECIPE_PATH_VALUE="$MYCROFT_DIR/recipes:$MYCROFT_GENERATED_RECIP
 includes 'python3 "$MYCROFT_DIR/install/setup_server.py" --profile-dir "$MYCROFT_PROFILE_DIR" --repo-dir "$MYCROFT_DIR"'
 includes 'MYCROFT_SETUP_CONFIG="$MYCROFT_PROFILE_DIR/setup-config.env"'
 includes 'if ! have bsig; then'
-includes 'if [ -f "$MYCROFT_PROFILE_DIR/engine-plan.ready" ]; then'
+includes 'rm -f "$ENGINE_PLAN_MARKER"'
+includes 'if [ -f "$ENGINE_PLAN_MARKER" ]; then'
 includes 'no legacy Obsidian/QMD fallback was applied'
+excludes 'reload to use the legacy installer'
 # No keys or choices baked into the script itself
 excludes '__CFG__'
 excludes 'ENV_EOF'

--- a/tests/setup-server-check.py
+++ b/tests/setup-server-check.py
@@ -168,11 +168,30 @@ class ServerChecks(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tmp = tempfile.mkdtemp()
+        cls.fake_bsig = os.path.join(cls.tmp, "bsig")
+        with open(cls.fake_bsig, "w", encoding="utf-8") as handle:
+            handle.write("""#!/usr/bin/env python3
+import json, sys
+args = sys.argv[1:]
+if args[:2] == ["configure", "describe"]:
+    data = {"descriptor": {"schema_version": "bsig-configure-descriptor/v1", "product": "mycroft", "fields": []}}
+elif args[:2] == ["configure", "validate"]:
+    json.load(sys.stdin); data = {"normalized": {"required_secret_ids": []}}
+elif args[:2] == ["keys", "list"]:
+    data = {"keys": []}
+elif args[:2] == ["configure", "plan"]:
+    json.load(sys.stdin); data = {"plan_path": "/tmp/mycroft-install.json"}
+else:
+    sys.exit(4)
+print(json.dumps({"event": "result", "data": data}))
+""")
+        os.chmod(cls.fake_bsig, 0o755)
+        env = {**os.environ, "BSIG_BINARY": cls.fake_bsig}
         cls.proc = subprocess.Popen(
             [sys.executable, os.path.join(ROOT, "install", "setup_server.py"),
              "--profile-dir", cls.tmp, "--repo-dir", ROOT,
              "--port", str(cls.PORT), "--no-browser", "--skip-key-validation"],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
         cls.token = None
         deadline = time.time() + 10
         while time.time() < deadline:
@@ -217,32 +236,30 @@ class ServerChecks(unittest.TestCase):
         self.assertIn("Optional fallback", self.page)
         self.assertNotIn('id="installFirecrawl" checked', self.page)
 
-        # 2. bad token is rejected on both POST endpoints
-        for path in ("/submit", "/pick-folder"):
+        # 2. bad token is rejected on both active POST endpoints
+        for path in ("/engine-submit", "/pick-folder"):
             with self.assertRaises(urllib.error.HTTPError) as ctx:
                 self.post(path, {**BASE, "token": "wrong"})
             self.assertEqual(ctx.exception.code, 403)
 
-        # 3. structural validation still blocks genuinely required fields
+        # 3. the legacy writer endpoint is retired
         with self.assertRaises(urllib.error.HTTPError) as ctx:
             self.post("/submit", {**BASE, "token": self.token, "vault": ""})
-        body = json.loads(ctx.exception.read())
-        self.assertTrue(any(e["field"] == "vault_path" for e in body["errors"]))
+        self.assertEqual(ctx.exception.code, 410)
 
-        # 4. keyless sovereign submit writes all four artifacts and exits 0
-        resp = self.post("/submit", {**BASE, "token": self.token,
-                                     "installFirecrawl": False, "firecrawlKey": ""})
+        # 4. Engine submit writes only the sealed-plan marker and exits 0
+        resp = self.post("/engine-submit", {
+            "token": self.token,
+            "request": {"schema_version": "bsig-configure/v1"},
+            "secrets": {},
+        })
         self.assertTrue(resp["ok"])
         self.assertEqual(self.proc.wait(timeout=10), 0)
-        for name, mode in [(".env", 0o600), ("setup-config.env", 0o600),
-                           ("skill-registry.json", 0o644), ("getting-started.html", 0o644)]:
-            path = os.path.join(self.tmp, name)
-            self.assertTrue(os.path.exists(path), name)
-            self.assertEqual(os.stat(path).st_mode & 0o777, mode, name)
-        with open(os.path.join(self.tmp, "getting-started.html"), encoding="utf-8") as handle:
-            guide = handle.read()
-        for secret in SECRETS:
-            self.assertNotIn(secret, guide)
+        marker = os.path.join(self.tmp, "engine-plan.ready")
+        self.assertEqual(os.stat(marker).st_mode & 0o777, 0o600)
+        with open(marker, encoding="utf-8") as handle:
+            self.assertEqual(json.load(handle)["plan_path"], "/tmp/mycroft-install.json")
+        self.assertEqual(set(os.listdir(self.tmp)), {"bsig", "engine-plan.ready"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require a valid Engine descriptor before serving configuration
- retire the legacy configurator submit endpoint
- clear stale sealed-plan markers before each run
- test the real Engine bridge boundary with a fake bsig process

## Verification
- complete Mycroft install/contract/skill suite passes