### PR TITLE
chore(catalog): publish production Minisign trust root

### DIFF
--- a/catalog/bsig-release.pub
+++ b/catalog/bsig-release.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key A67B6C00F3141A55
+RWRVGhTzAGx7pqB8NEMCPW8uMr10Koa3wSoIH9OCqoCkL4GUqhQcwtU6

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
-untrusted comment: signature from bsig dev catalog key
-RURvQU7KInKaBsbbduazJA6zrr3NFXn92rImlRtXIQLFJjg535ZvcTUZ1CcPWEuIw35FAnvHLjlZ8K35RDZmtww8dF+2ol30cwQ=
-trusted comment: timestamp:1784369815	file:catalog.json
-Vm8o0hKZYzw0ajrGUEwgswZrd6BW8M0vTJzE0Gr5N8Vygb13xpFPnqmEbe0IIbmBLBnapM4f4+Pr2utIX8pGCA==
+untrusted comment: signature from Buried Signals production release key
+RURVGhTzAGx7ptu6AXT4F1FagJ/qmptNfuYqd1rEnLzciUymyz5DIht4BNVdJvQrmbW3f9gUzyEmzOtRvvUKM7Xa0Pi58qMm+gU=
+trusted comment: timestamp:1784380740	file:catalog.json
+dLYUl6UDSvrzYUmde0y1xQ675WqEwd1wl2Q4Ivbn0RBi7ibQp0/OdlgN+m0DAn/We1VMdk2SQyD4IoYecf/eAQ==


### PR DESCRIPTION
## What changed

- publishes the production-signed catalog generated from Engine
- publishes the matching Minisign public key beside the catalog

## Why

The previous catalog used the M1 development trust root. This coordinates Mycroft with Engine's production release and catalog signing key.

## Verification

- Engine `publish-catalog -check` confirms byte-identical catalog, signature, and public key
- `minisign -V` accepts the catalog with the published public key
- Mycroft recipe, installer, preflight, doctor, configurator, and grounding/provenance checks pass
- secret scan confirms no private key or password is present
