### PR TITLE
chore(catalog): publish member-channel catalog cleanup

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-19T01:40:00Z",
-  "release_sequence": 4,
+  "released_at": "2026-07-19T10:00:04Z",
+  "release_sequence": 5,
   "products": {
     "mycroft": {
       "version": "0.3.0",
@@ -1660,39 +1660,5 @@
       "sidecar": true
     }
   ],
-  "integrations": null,
-  "engine_release": {
-    "version": "0.1.0",
-    "minimum_catalog_sequence": 4,
-    "artifacts": {
-      "darwin-amd64": {
-        "url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-darwin-amd64.tar.gz",
-        "sha256": "ee4fb870dd586400a3b6dad74ed1d09c772fc98f0d3ab4850947ba5ab62bf6f9",
-        "signature_url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-darwin-amd64.tar.gz.minisig",
-        "archive": "tar.gz",
-        "binary": "bsig"
-      },
-      "darwin-arm64": {
-        "url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-darwin-arm64.tar.gz",
-        "sha256": "ce74c52ee23659feb0cfcbb55982ceef65090ce543483a0d2a96e6708a881b09",
-        "signature_url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-darwin-arm64.tar.gz.minisig",
-        "archive": "tar.gz",
-        "binary": "bsig"
-      },
-      "linux-amd64": {
-        "url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-linux-amd64.tar.gz",
-        "sha256": "08e120ef9c0aae02366f8038c6fcac12019e3be8bbda00d247ead940c391debc",
-        "signature_url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-linux-amd64.tar.gz.minisig",
-        "archive": "tar.gz",
-        "binary": "bsig"
-      },
-      "linux-arm64": {
-        "url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-linux-arm64.tar.gz",
-        "sha256": "9e098d1bb4facf09bc0c75c93c4b52bee9c2b9462172e38110d92c7615836351",
-        "signature_url": "https://github.com/buriedsignals/engine/releases/download/v0.1.0/bsig-linux-arm64.tar.gz.minisig",
-        "archive": "tar.gz",
-        "binary": "bsig"
-      }
-    }
-  }
+  "integrations": null
 }

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7pq8USvkb4301soeM5ojA9BG037v8r5wjI0eDQkE4rDtsCj2reTPHY5TJbL6yUL1CAX88EMu/1eN/x28cIO47YwA=
-trusted comment: timestamp:1784425525	file:catalog.json
-8YQS64AgeNvtmsMQJe2f281iVjJ/38q1bgH0sEpm3R3AQNpTJsX64KmBF+rYxWyXDvXRwfqzUAOX3jQae2aKDQ==
+RURVGhTzAGx7ph33abmviUh+Ay/tp82auCYSD3+kGxMb54GOWascBapcu5xvD+5fST1tTiuAbI6Gk/E3pi1LU8fYblguKMhzcgY=
+trusted comment: timestamp:1784455341	file:catalog.json
+XO9Frh3Lrif89yZjkydRNlTbPGJsat82503IvJmRmkslYLr9KPpm6wFqjKIXnnUdJ+FWBWSMTFU6mKCjpyrfDg==


### PR DESCRIPTION
Publishes the byte-identical signed Engine catalog after removal of obsolete private GitHub Engine release URLs. Verified with Engine `publish-catalog -check` and full race-enabled tests.