### PR TITLE
chore(release): publish catalog for Mycroft 0.3.1

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-19T10:00:04Z",
-  "release_sequence": 5,
+  "released_at": "2026-07-20T14:06:11Z",
+  "release_sequence": 6,
   "products": {
     "mycroft": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "repo": "buriedsignals/mycroft",
-      "ref": "d0532df0e7bd5803423dc743a4398a8855d92a51",
+      "ref": "f1a58abcbe357f82a82cd1eb323728dba818b657",
       "entitlement": "mycroft.core",
       "install_contract": {
         "schema_version": "mycroft-install-contract/v1",
-        "source_commit": "d0532df0e7bd5803423dc743a4398a8855d92a51",
+        "source_commit": "f1a58abcbe357f82a82cd1eb323728dba818b657",
         "digest": "e1e0bccb34a8b28a0d046fb88d474c21afc937f05b19db5ccd6b2a88e45191ca",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7ph33abmviUh+Ay/tp82auCYSD3+kGxMb54GOWascBapcu5xvD+5fST1tTiuAbI6Gk/E3pi1LU8fYblguKMhzcgY=
-trusted comment: timestamp:1784455341	file:catalog.json
-XO9Frh3Lrif89yZjkydRNlTbPGJsat82503IvJmRmkslYLr9KPpm6wFqjKIXnnUdJ+FWBWSMTFU6mKCjpyrfDg==
+RURVGhTzAGx7plETgFVsHK8uzQlHuNQP/f9ZuZnnEaQUK1CScXlFPTyCHWgQQNVJGv5QYjleljyVUQlEd1bEH2NJ2TD4/alhaAU=
+trusted comment: timestamp:1784556670	file:catalog.json
+ZaE9yWFCvMQVhOmCcRMABqr34Pxquf1Gr1KPm9FFFbyrjvLw2A610EEVo7vaUzp4T0k2MNwGI05SAlFhynU6AA==


### PR DESCRIPTION
Publishes the byte-identical production-signed Engine catalog for Mycroft 0.3.1. The catalog binds the immutable v0.3.1 source commit, advances the anti-rollback sequence to 6, and preserves the existing contract digest.