### PR TITLE
chore(release): publish catalog for Mycroft 0.3.2

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T14:06:11Z",
-  "release_sequence": 6,
+  "released_at": "2026-07-20T14:38:47Z",
+  "release_sequence": 7,
   "products": {
     "mycroft": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "repo": "buriedsignals/mycroft",
-      "ref": "f1a58abcbe357f82a82cd1eb323728dba818b657",
+      "ref": "e58501948dd868a49025d7922163047abc00289a",
       "entitlement": "mycroft.core",
       "install_contract": {
         "schema_version": "mycroft-install-contract/v1",
-        "source_commit": "f1a58abcbe357f82a82cd1eb323728dba818b657",
+        "source_commit": "e58501948dd868a49025d7922163047abc00289a",
         "digest": "e1e0bccb34a8b28a0d046fb88d474c21afc937f05b19db5ccd6b2a88e45191ca",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7plETgFVsHK8uzQlHuNQP/f9ZuZnnEaQUK1CScXlFPTyCHWgQQNVJGv5QYjleljyVUQlEd1bEH2NJ2TD4/alhaAU=
-trusted comment: timestamp:1784556670	file:catalog.json
-ZaE9yWFCvMQVhOmCcRMABqr34Pxquf1Gr1KPm9FFFbyrjvLw2A610EEVo7vaUzp4T0k2MNwGI05SAlFhynU6AA==
+RURVGhTzAGx7pnPuAd4BGkyIp14Oh4s3F5FRPYsjugYMfw85i5GAAx+hTBGY7sZ8hrX83/JUJsgqG0ewdCMYVS7Dz8wVmwXeugg=
+trusted comment: timestamp:1784558409	file:catalog.json
+TJLUhTI9SPcbSnc4JK47tKtF6w39kBtSQev4aoT3J8S9lmfpWyufODDe3uGcboVI3MpqGL476KHmuTgjZo2/Bg==


### PR DESCRIPTION
Publishes the byte-identical production-signed Engine catalog for Mycroft 0.3.2. The catalog binds source commit e58501948dd868a49025d7922163047abc00289a and advances the anti-rollback sequence to 7.