### PR TITLE
fix(release): pin hosted installer to Mycroft 0.3.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ if [ "${1:-}" = "--provision-from-public-bundle" ]; then
 fi
 
 if [ "$PUBLIC_BUNDLE_PHASE" = "0" ]; then
-  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/mycroft/releases/download/v0.3.1"
+  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/mycroft/releases/download/v0.3.2"
   PUBLIC_BOOTSTRAP_SHA256="ebe0a8b707f4b891e2b9c87fe6b65da5e31f6a4140361faf0d99400c4f9a47a7"
   command -v curl >/dev/null 2>&1 || { echo "Mycroft installer: curl is required" >&2; exit 1; }
   command -v openssl >/dev/null 2>&1 || { echo "Mycroft installer: OpenSSL is required" >&2; exit 1; }


### PR DESCRIPTION
Moves the website bootstrap to the verified v0.3.2 signed bundle containing the Goose 1.43 and OpenKnowledge live-acceptance fixes. The shared bootstrap/applicator digests are unchanged.