### PR TITLE
chore(release): publish catalog for Mycroft 0.3.3

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T14:38:47Z",
-  "release_sequence": 7,
+  "released_at": "2026-07-20T14:55:16Z",
+  "release_sequence": 8,
   "products": {
     "mycroft": {
-      "version": "0.3.2",
+      "version": "0.3.3",
       "repo": "buriedsignals/mycroft",
-      "ref": "e58501948dd868a49025d7922163047abc00289a",
+      "ref": "44132df129b83e1cda9a3f1a435c1902ea5b6962",
       "entitlement": "mycroft.core",
       "install_contract": {
         "schema_version": "mycroft-install-contract/v1",
-        "source_commit": "e58501948dd868a49025d7922163047abc00289a",
+        "source_commit": "44132df129b83e1cda9a3f1a435c1902ea5b6962",
         "digest": "e1e0bccb34a8b28a0d046fb88d474c21afc937f05b19db5ccd6b2a88e45191ca",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7pnPuAd4BGkyIp14Oh4s3F5FRPYsjugYMfw85i5GAAx+hTBGY7sZ8hrX83/JUJsgqG0ewdCMYVS7Dz8wVmwXeugg=
-trusted comment: timestamp:1784558409	file:catalog.json
-TJLUhTI9SPcbSnc4JK47tKtF6w39kBtSQev4aoT3J8S9lmfpWyufODDe3uGcboVI3MpqGL476KHmuTgjZo2/Bg==
+RURVGhTzAGx7pjfz3CsqmT/H0iaUEuT0kaxgM4GrnzIPV5RTQ8qMo+dO/Mbw2M4nPXGVnv8IPm25JV3WXHjMQo1/YLET3g15+Aw=
+trusted comment: timestamp:1784559392	file:catalog.json
+PP4ZjFikkdWlYM4nLXLnRozuWD4DqrTsXv3HBUNNag6+1dDDciYrSeBEXjmFM0kw+Eze9/+vMb8BQrBUdEh1Dg==


### PR DESCRIPTION
Publishes the byte-identical production-signed catalog for Mycroft 0.3.3, binding source commit 44132df129b83e1cda9a3f1a435c1902ea5b6962 and sequence 8.