### PR TITLE
Publish Mycroft v0.3.4 catalog

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T14:55:16Z",
-  "release_sequence": 8,
+  "released_at": "2026-07-20T15:54:14Z",
+  "release_sequence": 9,
   "products": {
     "mycroft": {
-      "version": "0.3.3",
+      "version": "0.3.4",
       "repo": "buriedsignals/mycroft",
-      "ref": "44132df129b83e1cda9a3f1a435c1902ea5b6962",
+      "ref": "316d6981bf80d7e3f0943aca6e8e505e97d6f2c6",
       "entitlement": "mycroft.core",
       "install_contract": {
         "schema_version": "mycroft-install-contract/v1",
-        "source_commit": "44132df129b83e1cda9a3f1a435c1902ea5b6962",
+        "source_commit": "316d6981bf80d7e3f0943aca6e8e505e97d6f2c6",
         "digest": "e1e0bccb34a8b28a0d046fb88d474c21afc937f05b19db5ccd6b2a88e45191ca",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7pjfz3CsqmT/H0iaUEuT0kaxgM4GrnzIPV5RTQ8qMo+dO/Mbw2M4nPXGVnv8IPm25JV3WXHjMQo1/YLET3g15+Aw=
-trusted comment: timestamp:1784559392	file:catalog.json
-PP4ZjFikkdWlYM4nLXLnRozuWD4DqrTsXv3HBUNNag6+1dDDciYrSeBEXjmFM0kw+Eze9/+vMb8BQrBUdEh1Dg==
+RURVGhTzAGx7pinlh6Skzvq/B2S3CqYCTW3yUBkhwy0qRYIcVQU/rGoKcY4lT1H5CDQF0A3rqnHCmbPVnB1S1HHL8EFBgL5yIAw=
+trusted comment: timestamp:1784563034	file:catalog.json
+SzDwphaWN5AePjiJNhAo3hKB2+Q868CZma21CpSAQ1jXMjZmucgdZmXjr+YGPAN7NYx1HuFha2A8ThrrUt61AQ==


### PR DESCRIPTION
## Summary
- advance the signed catalog to release sequence 9
- publish Mycroft 0.3.4 at immutable tag/source commit `316d6981bf80d7e3f0943aca6e8e505e97d6f2c6`
- preserve the existing install-contract digest; this release updates the public applicator lifecycle

## Verification
- catalog signature verified with the published Minisign key
- Engine public-installer export/contract matrix will validate this catalog before release