### PR TITLE
Publish Spotlight v2.1.1 catalog

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T15:54:14Z",
-  "release_sequence": 9,
+  "released_at": "2026-07-20T16:03:40Z",
+  "release_sequence": 10,
   "products": {
     "mycroft": {
       "version": "0.3.4",
@@ -590,13 +590,13 @@
       }
     },
     "spotlight": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "repo": "buriedsignals/spotlight",
-      "ref": "ad5212ad78eec2bcedaad834376e495acc49367e",
+      "ref": "30d169e6922d1a1a6acbf4c9c232e40df3d2dff5",
       "entitlement": "spotlight.core",
       "install_contract": {
         "schema_version": "spotlight-install-contract/v1",
-        "source_commit": "ad5212ad78eec2bcedaad834376e495acc49367e",
+        "source_commit": "30d169e6922d1a1a6acbf4c9c232e40df3d2dff5",
         "digest": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7pinlh6Skzvq/B2S3CqYCTW3yUBkhwy0qRYIcVQU/rGoKcY4lT1H5CDQF0A3rqnHCmbPVnB1S1HHL8EFBgL5yIAw=
-trusted comment: timestamp:1784563034	file:catalog.json
-SzDwphaWN5AePjiJNhAo3hKB2+Q868CZma21CpSAQ1jXMjZmucgdZmXjr+YGPAN7NYx1HuFha2A8ThrrUt61AQ==
+RURVGhTzAGx7pgTGL1U3vdZVFZFuXPTZtye4y86Z0weMp+O5wrOhs3GbyEcF6RaTJwZV4tLsZbMH3s2Hq0TO+AHmfUYDoO6YGQE=
+trusted comment: timestamp:1784563517	file:catalog.json
+ImukODsNtKQquYJTh3S1ZqPt+Y0q3ETWge3T/BN8Q2BujU5OrjbP9/sjz3JLE13VaAUcnKAkrze+62XjceiJAg==


### PR DESCRIPTION
## Summary
- advance the signed catalog to release sequence 10
- publish Spotlight 2.1.1 at immutable tag/source commit `30d169e6922d1a1a6acbf4c9c232e40df3d2dff5`
- preserve the Spotlight install-contract digest; this revision carries the corrected generic public applicator lifecycle

## Verification
- catalog signature verified with the published Minisign key
- Engine public-installer export/contract matrix validates the synchronized catalog before release