### PR TITLE
chore(release): publish catalog for Spotlight 2.1.2

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T16:03:40Z",
-  "release_sequence": 10,
+  "released_at": "2026-07-20T18:10:35Z",
+  "release_sequence": 11,
   "products": {
     "mycroft": {
       "version": "0.3.4",
@@ -590,13 +590,13 @@
       }
     },
     "spotlight": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "repo": "buriedsignals/spotlight",
-      "ref": "30d169e6922d1a1a6acbf4c9c232e40df3d2dff5",
+      "ref": "cfc44910be54f3919c25bca546d2e35e84259d05",
       "entitlement": "spotlight.core",
       "install_contract": {
         "schema_version": "spotlight-install-contract/v1",
-        "source_commit": "30d169e6922d1a1a6acbf4c9c232e40df3d2dff5",
+        "source_commit": "cfc44910be54f3919c25bca546d2e35e84259d05",
         "digest": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7pgTGL1U3vdZVFZFuXPTZtye4y86Z0weMp+O5wrOhs3GbyEcF6RaTJwZV4tLsZbMH3s2Hq0TO+AHmfUYDoO6YGQE=
-trusted comment: timestamp:1784563517	file:catalog.json
-ImukODsNtKQquYJTh3S1ZqPt+Y0q3ETWge3T/BN8Q2BujU5OrjbP9/sjz3JLE13VaAUcnKAkrze+62XjceiJAg==
+RURVGhTzAGx7podJVvmtHp45fsE3dgHrLq6Zwf5+ZVQKN0cqCxLew1XNJEShDMHrV+0ELCABUkXmB8yL0KGmx0R4qOwa2CtZrA0=
+trusted comment: timestamp:1784571192	file:catalog.json
+sn/p8a+t0Mb9xKpSpLJnGuCSMNlamiMTcGc8C3dVA/XyAP7wrt+60en9OfcGjabEvwNlSZtrAa1gl2TnlALbCA==


### PR DESCRIPTION
Publishes Engine catalog sequence 11 byte-for-byte into Mycroft, pinning Spotlight 2.1.2 and its executable-mode lifecycle fix.