### PR TITLE
chore(release): publish catalog for Spotlight 2.1.3

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T18:10:35Z",
-  "release_sequence": 11,
+  "released_at": "2026-07-20T18:37:31Z",
+  "release_sequence": 12,
   "products": {
     "mycroft": {
       "version": "0.3.4",
@@ -590,13 +590,13 @@
       }
     },
     "spotlight": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "repo": "buriedsignals/spotlight",
-      "ref": "cfc44910be54f3919c25bca546d2e35e84259d05",
+      "ref": "01e46d957ba7c4fa761f4e67692df75c3cffc93c",
       "entitlement": "spotlight.core",
       "install_contract": {
         "schema_version": "spotlight-install-contract/v1",
-        "source_commit": "cfc44910be54f3919c25bca546d2e35e84259d05",
+        "source_commit": "01e46d957ba7c4fa761f4e67692df75c3cffc93c",
         "digest": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7podJVvmtHp45fsE3dgHrLq6Zwf5+ZVQKN0cqCxLew1XNJEShDMHrV+0ELCABUkXmB8yL0KGmx0R4qOwa2CtZrA0=
-trusted comment: timestamp:1784571192	file:catalog.json
-sn/p8a+t0Mb9xKpSpLJnGuCSMNlamiMTcGc8C3dVA/XyAP7wrt+60en9OfcGjabEvwNlSZtrAa1gl2TnlALbCA==
+RURVGhTzAGx7pvXfHaGxazmxM3bjBDWO42juOpA2N6YRJOfvCDsh0UVMbouyGRK/gJuENpLx5uzXZNo/VmLsuWezqpMEsXJTNQw=
+trusted comment: timestamp:1784573398	file:catalog.json
+IJI+um5+ZhaIION0stUKuQG+ek4dH61FhKMAEQVh5ry2jWV23G6hawz0C0s8ShD25qItv64epfMmZ5kqZV5bDg==


### PR DESCRIPTION
## What changed

- publish the byte-identical Engine catalog sequence 12 and production signature
- expose Spotlight 2.1.3 as the active catalog product version

## Why

Engine CI requires the public Mycroft catalog projection to match the authored catalog before activation. This keeps the shared skill/install registry synchronized across the release channel.

## Validation

- `bash tests/install-preflight-check.sh`
- Engine catalog signature and authored/published parity checks

