### PR TITLE
chore(release): publish catalog for Spotlight 2.1.4

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T18:37:31Z",
-  "release_sequence": 12,
+  "released_at": "2026-07-20T19:05:07Z",
+  "release_sequence": 13,
   "products": {
     "mycroft": {
       "version": "0.3.4",
@@ -590,7 +590,7 @@
       }
     },
     "spotlight": {
-      "version": "2.1.3",
+      "version": "2.1.4",
       "repo": "buriedsignals/spotlight",
       "ref": "01e46d957ba7c4fa761f4e67692df75c3cffc93c",
       "entitlement": "spotlight.core",

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7pvXfHaGxazmxM3bjBDWO42juOpA2N6YRJOfvCDsh0UVMbouyGRK/gJuENpLx5uzXZNo/VmLsuWezqpMEsXJTNQw=
-trusted comment: timestamp:1784573398	file:catalog.json
-IJI+um5+ZhaIION0stUKuQG+ek4dH61FhKMAEQVh5ry2jWV23G6hawz0C0s8ShD25qItv64epfMmZ5kqZV5bDg==
+RURVGhTzAGx7pi4Y8RuQWNJEPH9Ml9gz6FuRhNFKjPC7k8t3GEMu22sKxGx9mA8w2del54H28/+Vr8oZd+RlR0m/51+KNXapdw4=
+trusted comment: timestamp:1784574419	file:catalog.json
+q1kEAxO133q7/G/H3LgAG5pyex7RnUZTKsXuMQ2cTBGYPOsxeA5aPeOKRt68PSn1ycdWsh3CKdH3mgF4TvZ5Aw==


### PR DESCRIPTION
## What changed

- publish the byte-identical Engine catalog sequence 13 and production signature
- expose Spotlight 2.1.4 as the active catalog product version

## Why

This synchronizes Mycroft’s public catalog projection before Engine activates the signed generated-path migration bundle.

## Validation

- `bash tests/install-preflight-check.sh`
- Engine catalog signature and authored/published parity checks

