### PR TITLE
Sync signed catalog for Spotlight 2.1.5

### DIFF
--- a/catalog/catalog.json
+++ b/catalog/catalog.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "min_engine_version": "0.1.0",
-  "released_at": "2026-07-20T19:05:07Z",
-  "release_sequence": 13,
+  "released_at": "2026-07-20T19:23:36Z",
+  "release_sequence": 14,
   "products": {
     "mycroft": {
       "version": "0.3.4",
@@ -590,13 +590,13 @@
       }
     },
     "spotlight": {
-      "version": "2.1.4",
+      "version": "2.1.5",
       "repo": "buriedsignals/spotlight",
-      "ref": "01e46d957ba7c4fa761f4e67692df75c3cffc93c",
+      "ref": "05419e0c6cb1760f2eceee0c5175f70312d0d080",
       "entitlement": "spotlight.core",
       "install_contract": {
         "schema_version": "spotlight-install-contract/v1",
-        "source_commit": "01e46d957ba7c4fa761f4e67692df75c3cffc93c",
+        "source_commit": "05419e0c6cb1760f2eceee0c5175f70312d0d080",
         "digest": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
         "writer_mode": "engine_v2",
         "choice_schema": {

--- a/catalog/catalog.json.minisig
+++ b/catalog/catalog.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from Buried Signals production release key
-RURVGhTzAGx7pi4Y8RuQWNJEPH9Ml9gz6FuRhNFKjPC7k8t3GEMu22sKxGx9mA8w2del54H28/+Vr8oZd+RlR0m/51+KNXapdw4=
-trusted comment: timestamp:1784574419	file:catalog.json
-q1kEAxO133q7/G/H3LgAG5pyex7RnUZTKsXuMQ2cTBGYPOsxeA5aPeOKRt68PSn1ycdWsh3CKdH3mgF4TvZ5Aw==
+RURVGhTzAGx7ppPaHEZmfQ57KpV8wSI77EqxcdpWQloVjffuKeFa2UrzC8nq+xgkxZiLXVMYiT6syr60PbT1Snr6TIGhz+bpgQs=
+trusted comment: timestamp:1784575510	file:catalog.json
+ui1VQh97HM4Je2LPVoP8OAGiVYgiFrDZBWV/SIHIsbY7o1zg0utinLe7Z2LZ19Ecfe8NjcmSKRjsBVhfZ0/+Cw==


### PR DESCRIPTION
## Summary
- synchronize Engine catalog release sequence 14
- expose the immutable Spotlight v2.1.5 source through Mycroft's hosted catalog
- preserve the production minisign signature

## Verification
- Engine publish-catalog completed successfully
- minisign verification passed
- catalog contains Spotlight 2.1.5 at source commit 05419e0c6cb1760f2eceee0c5175f70312d0d080