### PR TITLE
fix(install): unblock macOS empty-array bootstrap and WSL browser open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 > changes shape, which is a breaking change for downstream consumers parsing
 > `cases/{project}/data/fact-check.json` or the legacy SIFT manifest.
 
+### Fixed — public installer on macOS and Windows (WSL)
+
+- The public bootstrap still shipped on `v0.3.5` expands empty `CHOICES_ARGS`
+  and `ACTION_ARGS` arrays under `set -u`, which aborts macOS `/bin/bash` 3.2
+  with `CHOICES_ARGS[@]: unbound variable`. After digest verification, `install.sh`
+  rewrites those expansions to the nounset-safe form already in Engine.
+- The localhost configurator no longer uses `xdg-open`/`gio` on WSL (that path
+  fails with `Operation not supported`). It opens `wslview` or Windows `cmd.exe`
+  instead, and prints the loopback URL if no GUI opener works.
+
 ### Changed — OpenKnowledge and Spotlight ownership
 
 - Mycroft writes durable notes through OpenKnowledge in its configured project.

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,7 @@ if [ "$PUBLIC_BUNDLE_PHASE" = "0" ] && [ "$PRIVATE_SOURCE_PHASE" = "0" ]; then
   PUBLIC_BOOTSTRAP_SHA256="ebe0a8b707f4b891e2b9c87fe6b65da5e31f6a4140361faf0d99400c4f9a47a7"
   command -v curl >/dev/null 2>&1 || { echo "Mycroft installer: curl is required" >&2; exit 1; }
   command -v openssl >/dev/null 2>&1 || { echo "Mycroft installer: OpenSSL is required" >&2; exit 1; }
+  command -v python3 >/dev/null 2>&1 || { echo "Mycroft installer: Python 3 is required" >&2; exit 1; }
   PUBLIC_BOOTSTRAP_TMP="$(mktemp "${TMPDIR:-/tmp}/mycroft-public-bootstrap.XXXXXX")"
   trap 'rm -f "$PUBLIC_BOOTSTRAP_TMP"' EXIT HUP INT TERM
   curl -fL --proto '=https' --tlsv1.2 "$PUBLIC_RELEASE_BASE/bootstrap.sh" -o "$PUBLIC_BOOTSTRAP_TMP"
@@ -67,6 +68,22 @@ if [ "$PUBLIC_BUNDLE_PHASE" = "0" ] && [ "$PRIVATE_SOURCE_PHASE" = "0" ]; then
     echo "Mycroft installer: public bootstrap digest did not verify" >&2
     exit 1
   }
+  # v0.3.5's published bootstrap expands empty arrays as "${CHOICES_ARGS[@]}"
+  # under `set -u`. macOS /bin/bash 3.2 aborts with "unbound variable" before
+  # the applicator runs. The current Engine bootstrap already uses the
+  # nounset-safe `${arr[@]+"${arr[@]}"}` form; rewrite the verified copy so
+  # this Pages-deployed install.sh unblocks Mac without replacing immutable
+  # v0.3.5 release assets. The rewrite is a no-op on a bootstrap that already
+  # has the safe form.
+  python3 - "$PUBLIC_BOOTSTRAP_TMP" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace('  "${CHOICES_ARGS[@]}" \\\n', '  "${CHOICES_ARGS[@]+"${CHOICES_ARGS[@]}"}" \\\n')
+text = text.replace('  "${ACTION_ARGS[@]}" \\\n', '  "${ACTION_ARGS[@]+"${ACTION_ARGS[@]}"}" \\\n')
+path.write_text(text, encoding="utf-8")
+PY
   bash "$PUBLIC_BOOTSTRAP_TMP" --product mycroft --release-base "$PUBLIC_RELEASE_BASE" --runtime goose
   exit $?
 fi
@@ -1486,6 +1503,8 @@ GETTING_STARTED="$MYCROFT_PROFILE_DIR/getting-started.html"
 if [ -f "$GETTING_STARTED" ]; then
   if [ "$(uname -s)" = "Darwin" ]; then
     open "$GETTING_STARTED" 2>/dev/null || true
+  elif have wslview; then
+    wslview "$GETTING_STARTED" >/dev/null 2>&1 || true
   elif have xdg-open; then
     xdg-open "$GETTING_STARTED" >/dev/null 2>&1 || true
   fi

--- a/install/setup_server.py
+++ b/install/setup_server.py
@@ -19,6 +19,7 @@ import os
 import platform
 import secrets
 import shlex
+import shutil
 import string
 import subprocess
 import sys
@@ -57,6 +58,102 @@ def detect_platform():
             pass
         return "linux"
     return "linux"
+
+
+WSL_CMD_CANDIDATES = (
+    "/mnt/c/Windows/System32/cmd.exe",
+    "/mnt/c/WINDOWS/System32/cmd.exe",
+)
+WSL_CMD_CWD_CANDIDATES = (
+    "/mnt/c/Windows/System32",
+    "/mnt/c/WINDOWS/System32",
+)
+
+
+def configurator_open_commands(
+    url,
+    *,
+    platform_id=None,
+    which=None,
+    isfile=None,
+    env=None,
+):
+    """Argv lists to try, in order, when opening the loopback configurator.
+
+    WSL's xdg-open often shells out to `gio`, which fails with
+    "Operation not supported". Prefer wslview or the Windows host cmd.exe
+    so the URL opens in a real Windows browser that can reach WSL2 localhost.
+    """
+    platform_id = detect_platform() if platform_id is None else platform_id
+    which = shutil.which if which is None else which
+    isfile = os.path.isfile if isfile is None else isfile
+    env = os.environ if env is None else env
+    commands = []
+    browser = str(env.get("BROWSER") or "").strip()
+    if browser:
+        commands.append([browser, url])
+    if platform_id == "mac":
+        commands.append(["open", url])
+        return commands
+    if platform_id == "windows-wsl":
+        wslview = which("wslview")
+        if wslview:
+            commands.append([wslview, url])
+        cmd = which("cmd.exe") or which("cmd")
+        if not cmd:
+            for candidate in WSL_CMD_CANDIDATES:
+                if isfile(candidate):
+                    cmd = candidate
+                    break
+        if cmd:
+            commands.append([cmd, "/c", "start", "", url])
+        return commands
+    xdg = which("xdg-open")
+    if xdg:
+        commands.append([xdg, url])
+    return commands
+
+
+def open_local_url(
+    url,
+    *,
+    platform_id=None,
+    which=None,
+    isfile=None,
+    isdir=None,
+    env=None,
+    run=None,
+    browser_open=None,
+):
+    """Open a 127.0.0.1 configurator URL. Returns True if an opener reported success."""
+    platform_id = detect_platform() if platform_id is None else platform_id
+    isdir = os.path.isdir if isdir is None else isdir
+    run = subprocess.run if run is None else run
+    browser_open = webbrowser.open if browser_open is None else browser_open
+    for argv in configurator_open_commands(
+        url, platform_id=platform_id, which=which, isfile=isfile, env=env
+    ):
+        extra = {}
+        basename = os.path.basename(argv[0]).lower() if argv else ""
+        if basename in {"cmd.exe", "cmd"}:
+            for cwd in WSL_CMD_CWD_CANDIDATES:
+                if isdir(cwd):
+                    extra["cwd"] = cwd
+                    break
+        try:
+            completed = run(argv, capture_output=True, timeout=15, **extra)
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+        if getattr(completed, "returncode", 1) == 0:
+            return True
+    if platform_id == "windows-wsl":
+        # Python's webbrowser module uses xdg-open → gio on WSL, which fails
+        # with "Operation not supported". Do not retry that path.
+        return False
+    try:
+        return bool(browser_open(url))
+    except Exception:
+        return False
 
 
 def pick_folder_natively(prompt):
@@ -742,10 +839,10 @@ def main():
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     if not args.no_browser:
-        try:
-            webbrowser.open(url)
-        except Exception:
-            pass
+        if not open_local_url(url):
+            print("  Could not open a browser automatically.", flush=True)
+            print("  Paste the Configurator URL into a browser on this computer.", flush=True)
+            print("  On Windows (WSL), open it in your Windows browser.", flush=True)
     try:
         finished = done.wait(SUBMIT_TIMEOUT_SECONDS)
     except KeyboardInterrupt:

--- a/tests/install-sh-check.sh
+++ b/tests/install-sh-check.sh
@@ -54,6 +54,10 @@ includes '--provision-from-private-source'
 includes 'if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]}" ]; then'
 includes 'if [ -n "$PRIVATE_INSTALLER_SOURCE" ] && [ -d "$PRIVATE_INSTALLER_SOURCE/.git" ]; then'
 includes 'git clone --no-local "$PRIVATE_INSTALLER_SOURCE" "$PRIVATE_MYCROFT_DIR"'
+includes 'Mycroft installer: Python 3 is required'
+includes '${CHOICES_ARGS[@]+"${CHOICES_ARGS[@]}"}'
+includes '${ACTION_ARGS[@]+"${ACTION_ARGS[@]}"}'
+includes 'wslview "$GETTING_STARTED"'
 # No keys or choices baked into the script itself
 excludes '__CFG__'
 excludes 'ENV_EOF'
@@ -163,6 +167,14 @@ excludes 'SPOT_DEVBROWSER'
 
 # Seed-note dates: quoted heredocs rely on the writer substituting $TODAY
 includes 'sed "s/\$TODAY/$TODAY/g" > "$path"'
+
+# macOS /bin/bash 3.2 treats empty "${arr[@]}" as unbound under `set -u`.
+# The published v0.3.5 bootstrap still uses that form; install.sh rewrites it
+# to the nounset-safe expansion after digest verification.
+if ! /bin/bash -c 'set -u; CHOICES_ARGS=(); : "${CHOICES_ARGS[@]}"' >/dev/null 2>&1; then
+  /bin/bash -c 'set -u; CHOICES_ARGS=(); ACTION_ARGS=(); : "${CHOICES_ARGS[@]+"${CHOICES_ARGS[@]}"}"; : "${ACTION_ARGS[@]+"${ACTION_ARGS[@]}"}"' \
+    || note "nounset-safe empty-array expansion failed under /bin/bash"
+fi
 
 if command -v shellcheck >/dev/null 2>&1; then
   shellcheck -S error install.sh || fail=1

--- a/tests/setup-server-check.py
+++ b/tests/setup-server-check.py
@@ -370,6 +370,80 @@ print(json.dumps({"event": "result", "data": data}))
         self.assertEqual(set(os.listdir(self.tmp)), {"bsig", "engine-plan.ready"})
 
 
+class BrowserOpenChecks(unittest.TestCase):
+    URL = "http://127.0.0.1:35347/?t=E5XFmNB5LTtXFuyrGBYaQw"
+
+    def test_wsl_prefers_wslview_then_windows_cmd(self):
+        cmds = srv.configurator_open_commands(
+            self.URL,
+            platform_id="windows-wsl",
+            which=lambda name: "/usr/bin/wslview" if name == "wslview" else None,
+            isfile=lambda path: False,
+            env={},
+        )
+        self.assertEqual(cmds, [["/usr/bin/wslview", self.URL]])
+
+    def test_wsl_uses_cmd_exe_when_wslview_is_missing(self):
+        cmds = srv.configurator_open_commands(
+            self.URL,
+            platform_id="windows-wsl",
+            which=lambda name: None,
+            isfile=lambda path: path == "/mnt/c/Windows/System32/cmd.exe",
+            env={},
+        )
+        self.assertEqual(cmds, [[
+            "/mnt/c/Windows/System32/cmd.exe", "/c", "start", "", self.URL,
+        ]])
+
+    def test_mac_uses_open(self):
+        cmds = srv.configurator_open_commands(
+            self.URL, platform_id="mac", which=lambda name: None,
+            isfile=lambda path: False, env={},
+        )
+        self.assertEqual(cmds, [["open", self.URL]])
+
+    def test_wsl_does_not_fall_back_to_webbrowser_gio(self):
+        webbrowser_calls = []
+
+        def fake_run(argv, **kwargs):
+            return subprocess.CompletedProcess(argv, 1, b"", b"gio: Operation not supported")
+
+        opened = srv.open_local_url(
+            self.URL,
+            platform_id="windows-wsl",
+            which=lambda name: None,
+            isfile=lambda path: False,
+            isdir=lambda path: False,
+            env={},
+            run=fake_run,
+            browser_open=lambda url: webbrowser_calls.append(url) or True,
+        )
+        self.assertFalse(opened)
+        self.assertEqual(webbrowser_calls, [])
+
+    def test_wsl_cmd_exe_success_opens_the_url(self):
+        runs = []
+
+        def fake_run(argv, **kwargs):
+            runs.append((argv, kwargs.get("cwd")))
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        opened = srv.open_local_url(
+            self.URL,
+            platform_id="windows-wsl",
+            which=lambda name: None,
+            isfile=lambda path: path == "/mnt/c/Windows/System32/cmd.exe",
+            isdir=lambda path: path == "/mnt/c/Windows/System32",
+            env={},
+            run=fake_run,
+            browser_open=lambda url: (_ for _ in ()).throw(AssertionError("webbrowser")),
+        )
+        self.assertTrue(opened)
+        self.assertEqual(runs, [([
+            "/mnt/c/Windows/System32/cmd.exe", "/c", "start", "", self.URL,
+        ], "/mnt/c/Windows/System32")])
+
+
 class FreshInstallGuardChecks(unittest.TestCase):
     def test_engine_required_never_exposes_legacy_submit_when_engine_is_missing(self):
         with tempfile.TemporaryDirectory() as profile:


### PR DESCRIPTION
## Summary
- After verifying the published `v0.3.5` bootstrap digest, rewrite empty-array expansions so macOS `/bin/bash` 3.2 no longer aborts with `CHOICES_ARGS[@]: unbound variable`.
- Open the localhost configurator with `wslview` or Windows `cmd.exe` on WSL instead of `xdg-open`/`gio`.

## Test plan
- [x] Rewrite applied to the live `v0.3.5` bootstrap; unsafe vs nounset-safe expansions reproduced on `/bin/bash` 3.2.57
- [x] `bash tests/install-sh-check.sh`
- [x] `python3 tests/setup-server-check.py`
- [ ] Re-run `curl -fsSL https://mycroft.buriedsignals.com/install.sh | bash` on the failing Mac and WSL hosts after Pages deploy